### PR TITLE
load_xpm: initialize s to NULL if no color is found

### DIFF
--- a/load_xpm.c
+++ b/load_xpm.c
@@ -75,6 +75,8 @@ load_xpm(xcb_connection_t *c, xcb_screen_t *screen, FILE *fp)
 			s = color->g4_color;
 		else if (color->m_color != NULL)
 			s = color->m_color;
+		else
+			s = NULL;
 
 		if (s == NULL || strcmp(s, "None") == 0)
 			s = "#000000";


### PR DESCRIPTION
else comparaison could be done against uninitialized value.

Please note I am unsure if it is a completely impossible senario or not (if `colorTable` has always one of these members not `NULL`): it depends of `XpmCreateXpmImageFromBuffer` behaviour.

(Was found using Clang static analyzer)