### PR TITLE
Add zsh completion file

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1,8 +1,12 @@
+zshcompletiondir=@zshcompletiondir@
+
 dist_man_MANS = xwallpaper.1
 
 bin_PROGRAMS = xwallpaper
 
-EXTRA_DIST = LICENSE README.md
+dist_zshcompletion_DATA = _xwallpaper
+
+EXTRA_DIST = LICENSE README.md _xwallpaper
 
 xwallpaper_SOURCES = functions.h main.c options.c outputs.c util.c
 xwallpaper_CPPFLAGS = @PIXMAN_CFLAGS@ @XCB_CFLAGS@

--- a/_xwallpaper
+++ b/_xwallpaper
@@ -1,0 +1,19 @@
+#compdef xwallpaper
+
+local curcontext="$curcontext" state line expl
+typeset -A opt_args
+
+_arguments \
+    '--screen[X screen number]:X screen number' \
+    '--no-randr[disable randr support]' \
+    '--output[output device]:output device:->outputs' \
+    '--center[center input file on the screen]:filename:_files' \
+    '--maximize[maximize input file on the screen without cropping]:filename:_files' \
+    '--stretch[stretch input file to fill entire screen]:filename:_files' \
+    '--zoom[maximize input file on the screen with cropping]:filename:_files' \
+    '--tile[repeat image to fill screen]:filename:_files' \
+    '--version[show version information]'
+
+case $state in
+	(outputs) _wanted outputs expl output compadd ${(uo)${(M)${(f)"$(_call_program outputs xrandr)"}:#* connected*}%% *} && return 0 ;;
+esac

--- a/configure.ac
+++ b/configure.ac
@@ -134,5 +134,10 @@ AS_IF([test "$xpm_ok" = yes],
 )
 AM_CONDITIONAL(BUILD_XPM, [test "$xpm_ok" = yes])
 
+AC_ARG_WITH([zshcompletiondir],
+ AS_HELP_STRING([--with-zshcompletiondir=DIR], [Zsh completions directory]),
+ [], [with_zshcompletiondir=${datadir}/zsh/vendor-completions])
+AC_SUBST([zshcompletiondir], [$with_zshcompletiondir])
+
 AC_CONFIG_FILES([Makefile])
 AC_OUTPUT


### PR DESCRIPTION
This adds a zsh completion file, which can be used for tab-completion
of xwallpaper's arguments in zsh. For proper completion of --output
parameter xrandr(1) must be installed.

Signed-off-by: Sebastian Reichel <sre@ring0.de>