### PR TITLE
zsh-completion: Some parameters may be specified multiple times

### DIFF
--- a/_xwallpaper
+++ b/_xwallpaper
@@ -4,14 +4,14 @@ local curcontext="$curcontext" state line expl
 typeset -A opt_args
 
 _arguments \
-    '--screen[X screen number]:X screen number' \
     '--no-randr[disable randr support]' \
-    '--output[output device]:output device:->outputs' \
-    '--center[center input file on the screen]:filename:_files' \
-    '--maximize[maximize input file on the screen without cropping]:filename:_files' \
-    '--stretch[stretch input file to fill entire screen]:filename:_files' \
-    '--zoom[maximize input file on the screen with cropping]:filename:_files' \
-    '--tile[repeat image to fill screen]:filename:_files' \
+    '*--screen[X screen number]:X screen number' \
+    '*--output[output device]:output device:->outputs' \
+    '*--center[center input file on the screen]:filename:_files' \
+    '*--maximize[maximize input file on the screen without cropping]:filename:_files' \
+    '*--stretch[stretch input file to fill entire screen]:filename:_files' \
+    '*--zoom[maximize input file on the screen with cropping]:filename:_files' \
+    '*--tile[repeat image to fill screen]:filename:_files' \
     '--version[show version information]'
 
 case $state in


### PR DESCRIPTION
--output and image parameters can be provided multiple
times. This fixes zsh auto-completion for this use case.

Signed-off-by: Sebastian Reichel <sre@ring0.de>