### PR TITLE
Install zsh completer to site-functions

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -142,7 +142,7 @@ AM_CONDITIONAL(BUILD_XPM, [test "$xpm_ok" = yes])
 
 AC_ARG_WITH([zshcompletiondir],
  AS_HELP_STRING([--with-zshcompletiondir=DIR], [Zsh completions directory]),
- [], [with_zshcompletiondir=${datadir}/zsh/vendor-completions])
+ [], [with_zshcompletiondir=${datadir}/zsh/site-functions])
 AC_SUBST([zshcompletiondir], [$with_zshcompletiondir])
 
 AC_CONFIG_FILES([Makefile])


### PR DESCRIPTION
vendor-completions is a Debian-ism that many distros and other OSes don't support. site-functions is added to the default `$fpath` by zsh, so it should just work for all users.