### PR TITLE
add webp image support

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -49,4 +49,12 @@ else
 EXTRA_DIST += load_xpm.c
 endif
 
+if BUILD_WEBP
+xwallpaper_SOURCES += load_webp.c
+xwallpaper_CPPFLAGS += @WEBP_CFLAGS@
+xwallpaper_LDADD += @WEBP_LIBS@
+else
+EXTRA_DIST += load_webp.c
+endif
+
 AM_CFLAGS = $(CWARNFLAGS)

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # xwallpaper
 
 The xwallpaper utility allows you to set image files as your X wallpaper.
-JPEG, PNG, and XPM file formats are supported, all of them being configurable
+JPEG, PNG, XPM and WebP file formats are supported, all of them being configurable
 and therefore no fixed dependencies.
 
 The wallpaper is also advertised to programs which support semi-transparent
@@ -30,8 +30,8 @@ Building and installing is as simple as:
     make
     make install
 
-To support all file formats, your system needs libjpeg-turbo, libpng, and
-libXpm. If one of the libraries is not found, the specific file format will
+To support all file formats, your system needs libjpeg-turbo, libpng,
+libXpm and libwebp. If one of the libraries is not found, the specific file format will
 not be supported. Also, if you compile for OpenBSD, the system call pledge
 is automatically used. On Linux systems, libseccomp is used if available to
 filter system calls.

--- a/configure.ac
+++ b/configure.ac
@@ -150,6 +150,30 @@ AS_IF([test "$xpm_ok" = yes],
 )
 AM_CONDITIONAL(BUILD_XPM, [test "$xpm_ok" = yes])
 
+# Check if WebP support is requested
+AC_MSG_CHECKING(whether WEBP support is requested)
+AC_ARG_WITH([webp],
+  [AS_HELP_STRING([--without-webp], [disable WEBP support])],
+  [
+   if test "$withval" = no ; then
+     webp_support=no
+   else
+     webp_support=yes
+   fi
+  ],
+  [ webp_support=auto ]
+)
+AC_MSG_RESULT($webp_support)
+if test "$webp_support" != no ; then
+  PKG_CHECK_MODULES(WEBP, libwebp >= 1.1, [webp_ok="yes"], [webp_ok="no"])
+else
+  webp_ok="no"
+fi
+AS_IF([test "$webp_ok" = yes],
+  [AC_DEFINE(WITH_WEBP,[1],[Define to 1 if you want WEBP support.])],[]
+)
+AM_CONDITIONAL(BUILD_WEBP, [test "$webp_ok" = yes])
+
 AC_ARG_WITH([zshcompletiondir],
  AS_HELP_STRING([--with-zshcompletiondir=DIR], [Zsh completions directory]),
  [], [with_zshcompletiondir=${datadir}/zsh/site-functions])

--- a/functions.h
+++ b/functions.h
@@ -89,6 +89,7 @@ wp_output_t	*get_outputs(xcb_connection_t *, xcb_screen_t *);
 pixman_image_t	*load_jpeg(FILE *);
 pixman_image_t	*load_png(FILE *);
 pixman_image_t	*load_xpm(xcb_connection_t *, xcb_screen_t *, FILE *);
+pixman_image_t	*load_webp(FILE *);
 wp_config_t	*parse_config(char **);
 void		 stage1_sandbox(void);
 void		 stage2_sandbox(void);

--- a/load_webp.c
+++ b/load_webp.c
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2021 Tobias Stoeckmann <tobias@stoeckmann.org>
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+#include <err.h>
+#include <limits.h>
+#include <pixman.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+#include <webp/decode.h>
+
+#include "functions.h"
+
+
+pixman_image_t *
+load_webp(FILE *fp)
+{
+	pixman_image_t *img;
+	uint8_t *data, *data_buffer, *p;
+  uint32_t *pixel, *pixels;
+	size_t data_size;
+	unsigned int width, height, ok, len;
+  WebPBitstreamFeatures feats;
+
+  fseek(fp, 0, SEEK_END);
+  data_size = ftell(fp);
+  fseek(fp, 0, SEEK_SET);
+
+  data = (uint8_t*)WebPMalloc(data_size + 1); // + 1 for \0 terminator
+  if (data == NULL) {
+    errx(1, "failed to allocate memory for WebP image data");
+    return NULL;
+  }
+
+  ok = (fread(data, data_size, 1, fp) == 1);
+	if (!ok) {
+		errx(1, "failed to read image data from WebP file");
+    WebPFree(data);
+		return NULL;
+	}
+
+	data_buffer = WebPDecodeARGB(data, data_size, &width, &height);
+
+  SAFE_MUL3(len, width, height, sizeof(*pixels));
+  pixel = pixels = xmalloc(len);
+
+  p = data_buffer;
+  for (int i = 0; i < width * height; i++) {
+    *pixel++ = (p[0]<<24) | (p[1]<<16) | (p[2]<<8) | (p[3]);
+    p += 4;
+  }
+
+  img = pixman_image_create_bits(PIXMAN_a8r8g8b8, width, height, pixels,
+      width * sizeof(uint32_t));
+
+  if (img == NULL)
+    errx(1, "failed to create pixman image");
+
+  WebPFree(data);
+  WebPFree(data_buffer);
+
+	return img;
+}

--- a/load_webp.c
+++ b/load_webp.c
@@ -33,7 +33,6 @@ load_webp(FILE *fp)
   uint32_t *pixel, *pixels;
 	size_t data_size;
 	unsigned int width, height, ok, len;
-  WebPBitstreamFeatures feats;
 
   fseek(fp, 0, SEEK_END);
   data_size = ftell(fp);

--- a/main.c
+++ b/main.c
@@ -85,6 +85,12 @@ load_pixman_image(xcb_connection_t *c, xcb_screen_t *screen, FILE *fp)
 		pixman_image = load_xpm(c, screen, fp);
 	}
 #endif /* WITH_XPM */
+#ifdef WITH_WEBP
+	if (pixman_image == NULL) {
+		rewind(fp);
+		pixman_image = load_webp(fp);
+	}
+#endif /* WITH_WEBP */
 
 	return pixman_image;
 }


### PR DESCRIPTION
Hi,
yesterday I downloaded some wallpapers in [webp](https://en.wikipedia.org/wiki/WebP) format and noticed that I cannot load them with xwallpaper.
So I went ahead and implemented webp decoding and I now want to share this with you.

My implementation mimics closely the ones for jpg, png and xpm formats.
The new optional dependency is libwebp, tested with version 1.1.0_2.

I hope someone can review and comment on this and perhaps even merge it.
