### PR TITLE
Adding farbfeld support

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -49,4 +49,10 @@ else
 EXTRA_DIST += load_xpm.c
 endif
 
+if BUILD_FARBFELD
+xwallpaper_SOURCES += load_farbfeld.c
+else
+EXTRA_DIST += load_farbfeld.c
+endif
+
 AM_CFLAGS = $(CWARNFLAGS)

--- a/configure.ac
+++ b/configure.ac
@@ -2,7 +2,7 @@
 # Process this file with autoconf to produce a configure script.
 
 AC_PREREQ([2.69])
-AC_INIT([xwallpaper], [0.7.0], [https://github.com/stoeckmann/xwallpaper/issues], [xwallpaper], [https://github.com/stoeckmann/xwallpaper])
+AC_INIT([xwallpaper], [0.6.6], [https://github.com/stoeckmann/xwallpaper/issues], [xwallpaper], [https://github.com/stoeckmann/xwallpaper])
 AC_CONFIG_SRCDIR([Makefile.am])
 AC_CONFIG_HEADERS([config.h])
 
@@ -149,6 +149,31 @@ AS_IF([test "$xpm_ok" = yes],
   [AC_DEFINE(WITH_XPM,[1],[Define to 1 if you want XPM support.])],[]
 )
 AM_CONDITIONAL(BUILD_XPM, [test "$xpm_ok" = yes])
+
+# Check if FARBFELD support is requested
+AC_MSG_CHECKING(whether FARBFELD support is requested)
+AC_ARG_WITH([farbfeld],
+  [AS_HELP_STRING([--without-farbfeld], [disable FARBFELD support])],
+  [
+   if test "$withval" = no ; then
+     farbfeld_support=no
+   else
+     farbfeld_support=yes
+   fi
+  ],
+  [ farbfeld_support=auto ]
+)
+AC_MSG_RESULT($farbfeld_support)
+if test "$farbfeld_support" != no ; then
+  farbfeld_ok="yes"
+else
+  farbfeld_ok="no"
+fi
+AS_IF([test "$farbfeld_ok" = yes],
+  [AC_DEFINE(WITH_FARBFELD,[1],[Define to 1 if you want FARBFELD support.])],[]
+)
+AM_CONDITIONAL(BUILD_FARBFELD, [test "$farbfeld_ok" = yes])
+
 
 AC_ARG_WITH([zshcompletiondir],
  AS_HELP_STRING([--with-zshcompletiondir=DIR], [Zsh completions directory]),

--- a/configure.ac
+++ b/configure.ac
@@ -2,7 +2,7 @@
 # Process this file with autoconf to produce a configure script.
 
 AC_PREREQ([2.69])
-AC_INIT([xwallpaper], [0.6.6], [https://github.com/stoeckmann/xwallpaper/issues], [xwallpaper], [https://github.com/stoeckmann/xwallpaper])
+AC_INIT([xwallpaper], [0.7.0], [https://github.com/stoeckmann/xwallpaper/issues], [xwallpaper], [https://github.com/stoeckmann/xwallpaper])
 AC_CONFIG_SRCDIR([Makefile.am])
 AC_CONFIG_HEADERS([config.h])
 

--- a/functions.h
+++ b/functions.h
@@ -96,6 +96,7 @@ wp_output_t	*get_outputs(xcb_connection_t *, xcb_screen_t *);
 pixman_image_t	*load_jpeg(FILE *);
 pixman_image_t	*load_png(FILE *);
 pixman_image_t	*load_xpm(xcb_connection_t *, xcb_screen_t *, FILE *);
+pixman_image_t	*load_farbfeld(FILE *);
 wp_config_t	*parse_config(char **);
 void		 stage1_sandbox(void);
 void		 stage2_sandbox(void);

--- a/load_farbfeld.c
+++ b/load_farbfeld.c
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2021 Tobias Stoeckmann <tobias@stoeckmann.org>
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+#include <pixman.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "functions.h"
+
+#define FF_MAGIC "farbfeld"
+
+
+/* using rob pike's byte order fallacy blog post */
+static uint32_t
+ffstol(uint8_t *data)
+{
+	return (data[3]<<0) | (data[2]<<8) | (data[1]<<16) | (data[0]<<24);
+}
+
+pixman_image_t *
+load_farbfeld(FILE *fp)
+{
+	pixman_image_t *img;
+	uint8_t *buf;
+	uint8_t a, r, g, b;
+	uint32_t *pixels, *pixel, width, height;
+	size_t len;
+
+	/* the farbfeld header is 16 bytes long */
+	buf = xmalloc(8*sizeof(uint8_t));
+	fread(buf, sizeof(uint8_t), 8, fp);
+	if (memcmp(FF_MAGIC, (uint8_t *) buf, 8) != 0) {
+		debug("invalid farbfeld magic\n");
+		return NULL;
+	}
+	fread(buf, sizeof(uint8_t), 8, fp);
+	width = ffstol(buf);
+	height = ffstol(buf+4);
+
+	/* now comes the pixels */
+	SAFE_MUL3(len, height, width, sizeof(*pixels));
+	pixel = pixels = xmalloc(len);
+
+	/* here we naively convert to 8-bit per channel argb while reading */
+	while (feof(fp) == 0) {
+		fread(buf, sizeof(uint8_t), 8, fp);
+		r = buf[0];
+		g = buf[2];
+		b = buf[4];
+		a = buf[6];
+		*pixel = (a<<24) | (r<<16) | (g<<8) | (b<<0);
+		pixel++;
+	}
+	free(buf);
+
+	img = pixman_image_create_bits(PIXMAN_a8r8g8b8, width, height, pixels,
+	    width * sizeof(uint32_t));
+	if (img == NULL)
+		errx(1, "failed to create pixman image");
+
+	return img;
+}

--- a/load_farbfeld.c
+++ b/load_farbfeld.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Tobias Stoeckmann <tobias@stoeckmann.org>
+ * Copyright (c) 2021 Ricardo B. Ayres <ricardo.bosqueiro.ayres@gmail.com>
  *
  * Permission to use, copy, modify, and distribute this software for any
  * purpose with or without fee is hereby granted, provided that the above
@@ -70,8 +70,10 @@ load_farbfeld(FILE *fp)
 
 	img = pixman_image_create_bits(PIXMAN_a8r8g8b8, width, height, pixels,
 	    width * sizeof(uint32_t));
-	if (img == NULL)
+	if (img == NULL) {
 		errx(1, "failed to create pixman image");
+		free(pixels);
+	}
 
 	return img;
 }

--- a/main.c
+++ b/main.c
@@ -85,6 +85,12 @@ load_pixman_image(xcb_connection_t *c, xcb_screen_t *screen, FILE *fp)
 		pixman_image = load_xpm(c, screen, fp);
 	}
 #endif /* WITH_XPM */
+#ifdef WITH_FARBFELD
+	if (pixman_image == NULL) {
+		rewind(fp);
+		pixman_image = load_farbfeld(fp);
+	}
+#endif /* WITH_FARBBFELD */
 
 	return pixman_image;
 }


### PR DESCRIPTION
This adds farbfeld support to xwallpaper without requiring external libs.
I've written the parser because the file format is extremely simple and i believe it is unlikely to change.
The farbfeld image format is described here: http://tools.suckless.org/farbfeld/