### PR TITLE
add support for loongarch

### DIFF
--- a/seccomp.c
+++ b/seccomp.c
@@ -53,7 +53,9 @@ add_common_stage2_rules(scmp_filter_ctx ctx)
 	    seccomp_rule_add(ctx, SCMP_ACT_ALLOW, SCMP_SYS(fchdir), 0) ||
 	    seccomp_rule_add(ctx, SCMP_ACT_ALLOW, SCMP_SYS(fcntl), 0) ||
 	    seccomp_rule_add(ctx, SCMP_ACT_ALLOW, SCMP_SYS(fcntl64), 0) ||
+#if (defined(__SNR_fstat) && __SNR_fstat)
 	    seccomp_rule_add(ctx, SCMP_ACT_ALLOW, SCMP_SYS(fstat), 0) ||
+#endif
 	    seccomp_rule_add(ctx, SCMP_ACT_ALLOW, SCMP_SYS(fstat64), 0) ||
 	    seccomp_rule_add(ctx, SCMP_ACT_ALLOW, SCMP_SYS(fstatat64), 0) ||
 	    seccomp_rule_add(ctx, SCMP_ACT_ALLOW, SCMP_SYS(fsync), 0) ||


### PR DESCRIPTION
The package failed to compile at loong64 for the following detailed reasons:[https://buildd.debian.org/status/fetch.php?pkg=xwallpaper&arch=loong64&ver=0.7.3-1&stamp=1714048507&raw=0](url)