### PR TITLE
Fix loong64 compilation

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 ISC License
 
-Copyright (c) 2022 Tobias Stoeckmann <tobias@stoeckmann.org>
+Copyright (c) 2024 Tobias Stoeckmann <tobias@stoeckmann.org>
 
 Permission to use, copy, modify, and distribute this software for any
 purpose with or without fee is hereby granted, provided that the above

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ filter system calls.
 
 ## License
 
-Copyright (c) 2022 Tobias Stoeckmann <tobias@stoeckmann.org>
+Copyright (c) 2024 Tobias Stoeckmann <tobias@stoeckmann.org>
 
 Permission to use, copy, modify, and distribute this software for any
 purpose with or without fee is hereby granted, provided that the above

--- a/debug.c
+++ b/debug.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Tobias Stoeckmann <tobias@stoeckmann.org>
+ * Copyright (c) 2024 Tobias Stoeckmann <tobias@stoeckmann.org>
  *
  * Permission to use, copy, modify, and distribute this software for any
  * purpose with or without fee is hereby granted, provided that the above

--- a/functions.h
+++ b/functions.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Tobias Stoeckmann <tobias@stoeckmann.org>
+ * Copyright (c) 2024 Tobias Stoeckmann <tobias@stoeckmann.org>
  *
  * Permission to use, copy, modify, and distribute this software for any
  * purpose with or without fee is hereby granted, provided that the above

--- a/load_jpeg.c
+++ b/load_jpeg.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Tobias Stoeckmann <tobias@stoeckmann.org>
+ * Copyright (c) 2024 Tobias Stoeckmann <tobias@stoeckmann.org>
  *
  * Permission to use, copy, modify, and distribute this software for any
  * purpose with or without fee is hereby granted, provided that the above

--- a/load_png.c
+++ b/load_png.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Tobias Stoeckmann <tobias@stoeckmann.org>
+ * Copyright (c) 2024 Tobias Stoeckmann <tobias@stoeckmann.org>
  *
  * Permission to use, copy, modify, and distribute this software for any
  * purpose with or without fee is hereby granted, provided that the above

--- a/load_xpm.c
+++ b/load_xpm.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Tobias Stoeckmann <tobias@stoeckmann.org>
+ * Copyright (c) 2024 Tobias Stoeckmann <tobias@stoeckmann.org>
  *
  * Permission to use, copy, modify, and distribute this software for any
  * purpose with or without fee is hereby granted, provided that the above

--- a/main.c
+++ b/main.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Tobias Stoeckmann <tobias@stoeckmann.org>
+ * Copyright (c) 2024 Tobias Stoeckmann <tobias@stoeckmann.org>
  *
  * Permission to use, copy, modify, and distribute this software for any
  * purpose with or without fee is hereby granted, provided that the above

--- a/options.c
+++ b/options.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Tobias Stoeckmann <tobias@stoeckmann.org>
+ * Copyright (c) 2024 Tobias Stoeckmann <tobias@stoeckmann.org>
  *
  * Permission to use, copy, modify, and distribute this software for any
  * purpose with or without fee is hereby granted, provided that the above

--- a/outputs.c
+++ b/outputs.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Tobias Stoeckmann <tobias@stoeckmann.org>
+ * Copyright (c) 2024 Tobias Stoeckmann <tobias@stoeckmann.org>
  *
  * Permission to use, copy, modify, and distribute this software for any
  * purpose with or without fee is hereby granted, provided that the above

--- a/seccomp.c
+++ b/seccomp.c
@@ -52,11 +52,15 @@ add_common_stage2_rules(scmp_filter_ctx ctx)
 	    seccomp_rule_add(ctx, SCMP_ACT_ALLOW, SCMP_SYS(exit_group), 0) ||
 	    seccomp_rule_add(ctx, SCMP_ACT_ALLOW, SCMP_SYS(fchdir), 0) ||
 	    seccomp_rule_add(ctx, SCMP_ACT_ALLOW, SCMP_SYS(fcntl), 0) ||
+#ifdef __NR_fcntl64
 	    seccomp_rule_add(ctx, SCMP_ACT_ALLOW, SCMP_SYS(fcntl64), 0) ||
-#if (defined(__SNR_fstat) && __SNR_fstat)
+#endif
+#ifdef __NR_fstat
 	    seccomp_rule_add(ctx, SCMP_ACT_ALLOW, SCMP_SYS(fstat), 0) ||
 #endif
+#ifdef __NR_fstat64
 	    seccomp_rule_add(ctx, SCMP_ACT_ALLOW, SCMP_SYS(fstat64), 0) ||
+#endif
 	    seccomp_rule_add(ctx, SCMP_ACT_ALLOW, SCMP_SYS(fstatat64), 0) ||
 	    seccomp_rule_add(ctx, SCMP_ACT_ALLOW, SCMP_SYS(fsync), 0) ||
 	    seccomp_rule_add(ctx, SCMP_ACT_ALLOW, SCMP_SYS(ftruncate), 0) ||
@@ -73,19 +77,31 @@ add_common_stage2_rules(scmp_filter_ctx ctx)
 	    seccomp_rule_add(ctx, SCMP_ACT_ALLOW, SCMP_SYS(getppid), 0) ||
 	    seccomp_rule_add(ctx, SCMP_ACT_ALLOW, SCMP_SYS(getresgid), 0) ||
 	    seccomp_rule_add(ctx, SCMP_ACT_ALLOW, SCMP_SYS(getresuid), 0) ||
+#ifdef __NR_getrlimit
 	    seccomp_rule_add(ctx, SCMP_ACT_ALLOW, SCMP_SYS(getrlimit), 0) ||
+#endif
 	    seccomp_rule_add(ctx, SCMP_ACT_ALLOW, SCMP_SYS(getsid), 0) ||
 	    seccomp_rule_add(ctx, SCMP_ACT_ALLOW, SCMP_SYS(gettimeofday), 0) ||
 	    seccomp_rule_add(ctx, SCMP_ACT_ALLOW, SCMP_SYS(getuid), 0) ||
 	    seccomp_rule_add(ctx, SCMP_ACT_ALLOW, SCMP_SYS(lseek), 0) ||
+#ifdef __NR__llseek
 	    seccomp_rule_add(ctx, SCMP_ACT_ALLOW, SCMP_SYS(_llseek), 0) ||
+#endif
 	    seccomp_rule_add(ctx, SCMP_ACT_ALLOW, SCMP_SYS(madvise), 0) ||
+#ifdef __NR_mmap
 	    seccomp_rule_add(ctx, SCMP_ACT_ALLOW, SCMP_SYS(mmap), 0) ||
+#endif
+#ifdef __NR_mmap2
 	    seccomp_rule_add(ctx, SCMP_ACT_ALLOW, SCMP_SYS(mmap2), 0) ||
+#endif
 	    seccomp_rule_add(ctx, SCMP_ACT_ALLOW, SCMP_SYS(mprotect), 0) ||
 	    seccomp_rule_add(ctx, SCMP_ACT_ALLOW, SCMP_SYS(munmap), 0) ||
+#ifdef __NR_nanosleep
 	    seccomp_rule_add(ctx, SCMP_ACT_ALLOW, SCMP_SYS(nanosleep), 0) ||
+#endif
+#ifdef __NR_newfstatat
 	    seccomp_rule_add(ctx, SCMP_ACT_ALLOW, SCMP_SYS(newfstatat), 0) ||
+#endif
 	    seccomp_rule_add(ctx, SCMP_ACT_ALLOW, SCMP_SYS(pipe), 0) ||
 	    seccomp_rule_add(ctx, SCMP_ACT_ALLOW, SCMP_SYS(pipe2), 0) ||
 	    seccomp_rule_add(ctx, SCMP_ACT_ALLOW, SCMP_SYS(poll), 0) ||
@@ -106,7 +122,9 @@ add_common_stage2_rules(scmp_filter_ctx ctx)
 	    seccomp_rule_add(ctx, SCMP_ACT_ALLOW, SCMP_SYS(shutdown), 0) ||
 	    seccomp_rule_add(ctx, SCMP_ACT_ALLOW, SCMP_SYS(sigaction), 0) ||
 	    seccomp_rule_add(ctx, SCMP_ACT_ALLOW, SCMP_SYS(sigprocmask), 0) ||
+#ifdef __NR_sigreturn
 	    seccomp_rule_add(ctx, SCMP_ACT_ALLOW, SCMP_SYS(sigreturn), 0) ||
+#endif
 	    seccomp_rule_add(ctx, SCMP_ACT_ALLOW, SCMP_SYS(socketpair), 0) ||
 	    seccomp_rule_add(ctx, SCMP_ACT_ALLOW, SCMP_SYS(statx), 0) ||
 	    seccomp_rule_add(ctx, SCMP_ACT_ALLOW, SCMP_SYS(umask), 0) ||
@@ -137,7 +155,9 @@ stage1_sandbox(void)
 	    seccomp_rule_add(ctx, SCMP_ACT_ALLOW, SCMP_SYS(accept4), 0) ||
 	    seccomp_rule_add(ctx, SCMP_ACT_ALLOW, SCMP_SYS(bind), 0) ||
 	    seccomp_rule_add(ctx, SCMP_ACT_ALLOW, SCMP_SYS(listen), 0) ||
+#ifdef __NR_getpeername
 	    seccomp_rule_add(ctx, SCMP_ACT_ALLOW, SCMP_SYS(getpeername), 0) ||
+#endif
 	    seccomp_rule_add(ctx, SCMP_ACT_ALLOW, SCMP_SYS(getsockname), 0) ||
 	    seccomp_rule_add(ctx, SCMP_ACT_ALLOW, SCMP_SYS(getsockopt), 0) ||
 	    seccomp_rule_add(ctx, SCMP_ACT_ALLOW, SCMP_SYS(setsockopt), 0) ||
@@ -145,16 +165,24 @@ stage1_sandbox(void)
 	    seccomp_rule_add(ctx, SCMP_ACT_ALLOW, SCMP_SYS(chdir), 0) ||
 	    seccomp_rule_add(ctx, SCMP_ACT_ALLOW, SCMP_SYS(chmod), 0) ||
 	    seccomp_rule_add(ctx, SCMP_ACT_ALLOW, SCMP_SYS(chown), 0) ||
+#ifdef __NR_faccessat
 	    seccomp_rule_add(ctx, SCMP_ACT_ALLOW, SCMP_SYS(faccessat), 0) ||
+#endif
 	    seccomp_rule_add(ctx, SCMP_ACT_ALLOW, SCMP_SYS(fchmodat), 0) ||
+#ifdef __NR_fchmod
 	    seccomp_rule_add(ctx, SCMP_ACT_ALLOW, SCMP_SYS(fchmod), 0) ||
+#endif
 	    seccomp_rule_add(ctx, SCMP_ACT_ALLOW, SCMP_SYS(fchown), 0) ||
 	    seccomp_rule_add(ctx, SCMP_ACT_ALLOW, SCMP_SYS(fchownat), 0) ||
 	    seccomp_rule_add(ctx, SCMP_ACT_ALLOW, SCMP_SYS(getcwd), 0) ||
 	    seccomp_rule_add(ctx, SCMP_ACT_ALLOW, SCMP_SYS(lstat), 0) ||
+#ifdef __NR_open
 	    seccomp_rule_add(ctx, SCMP_ACT_ALLOW, SCMP_SYS(open), 0) ||
+#endif
 	    seccomp_rule_add(ctx, SCMP_ACT_ALLOW, SCMP_SYS(openat), 0) ||
+#ifdef __NR_readlinkat
 	    seccomp_rule_add(ctx, SCMP_ACT_ALLOW, SCMP_SYS(readlinkat), 0) ||
+#endif
 	    /* pledge: proc */
 	    seccomp_rule_add(ctx, SCMP_ACT_ALLOW, SCMP_SYS(clone), 0) ||
 	    seccomp_rule_add(ctx, SCMP_ACT_ALLOW, SCMP_SYS(set_robust_list), 0) ||

--- a/seccomp.c
+++ b/seccomp.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Tobias Stoeckmann <tobias@stoeckmann.org>
+ * Copyright (c) 2024 Tobias Stoeckmann <tobias@stoeckmann.org>
  *
  * Permission to use, copy, modify, and distribute this software for any
  * purpose with or without fee is hereby granted, provided that the above

--- a/util.c
+++ b/util.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Tobias Stoeckmann <tobias@stoeckmann.org>
+ * Copyright (c) 2024 Tobias Stoeckmann <tobias@stoeckmann.org>
  *
  * Permission to use, copy, modify, and distribute this software for any
  * purpose with or without fee is hereby granted, provided that the above

--- a/xwallpaper.1
+++ b/xwallpaper.1
@@ -1,4 +1,4 @@
-.\" Copyright (c) 2022 Tobias Stoeckmann <tobias@stoeckmann.org>
+.\" Copyright (c) 2024 Tobias Stoeckmann <tobias@stoeckmann.org>
 .\"
 .\" Permission to use, copy, modify, and distribute this software for any
 .\" purpose with or without fee is hereby granted, provided that the above


### PR DESCRIPTION
The `fstat` system call does not exist on this architecture anymore. While at it, put some more system calls into `ifdef` checks.

Inspired by file and tor:
- https://gitlab.torproject.org/tpo/core/tor/-/raw/main/src/lib/sandbox/sandbox.c?ref_type=heads
- https://sources.debian.org/src/file/1:5.45-3/src/seccomp.c/?hl=180#L180