### PR TITLE
Add (virtual) --desktop option, similar to --screen

### DIFF
--- a/_xwallpaper
+++ b/_xwallpaper
@@ -7,6 +7,7 @@ _arguments \
     '--clear[set background to black]' \
     '--daemon[enable daemon mode]' \
     '--debug[enable debug mode]' \
+    '*--desktop[X desktop number]:X desktop number' \
     '--no-atoms[no update of pseudo transparency atoms]' \
     '--no-randr[disable randr support]' \
     '--no-root[no update of root window background]' \

--- a/argparse.h
+++ b/argparse.h
@@ -1,0 +1,111 @@
+/*
+ * Copyright (c) 2025 Tobias Stoeckmann <tobias@stoeckmann.org>
+ * Copyright (c) 2026 Fredrik Noring
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+struct opt {
+	char s[16];
+};
+
+struct optarg {
+	int label;
+
+	int error;
+	const char *expect;
+
+	const char *name;
+	const char *string;
+	int integer;
+
+	int i;
+	wp_argcv_t arg;
+};
+
+static struct opt
+opt(const char *label)
+{
+	struct opt o = { };
+
+	for (size_t i = 0; i + 1 < sizeof(o.s); i++)
+		if (i < 2)
+			o.s[i] = '-';
+		else if (label[i - 2] == '\0')
+			break;
+		else if (label[i - 2] == '_')
+			o.s[i] = '-';
+		else
+			o.s[i] = label[i - 2];
+
+	return o;
+}
+
+static void
+optparse_void(struct optarg *oa)
+{
+}
+
+static void
+optparse_string(struct optarg *oa)
+{
+	if (oa->i >= oa->arg.c) {
+		oa->error = OPTION_MISSING;
+		return;
+	}
+
+	oa->i++;
+}
+
+static struct optarg
+optarg_next(struct optarg oa)
+{
+	if (oa.i >= oa.arg.c)
+		return (struct optarg) { .label = OPTION_END };
+
+#define OPTION_PARSE(name_, arg_, desc_)				\
+	if (strcmp(oa.arg.v[oa.i], opt(#name_).s) == 0) {		\
+		oa.label = OPTION_##name_;				\
+		oa.name = oa.arg.v[oa.i++];				\
+		oa.string = oa.arg.v[oa.i];				\
+		oa.expect = #arg_;					\
+		optparse_##arg_(&oa);					\
+		return oa;						\
+	}
+OPTIONS(OPTION_PARSE)
+
+	oa.label = OPTION_INVALID;
+	oa.error = OPTION_INVALID;
+	oa.name = oa.arg.v[oa.i++];
+	oa.string = "";
+
+	return oa;
+}
+
+static struct optarg
+optarg_init(wp_argcv_t args)
+{
+	return optarg_next((struct optarg) { .i = 1, .arg = args });
+}
+
+#define for_each_option(args_)						\
+	for (struct optarg oa_ = optarg_init(args_);			\
+	     oa_.label != OPTION_END;					\
+	     oa_ = optarg_next(oa_))
+
+#define option_label	(oa_.label)
+#define option_error	(oa_.error)
+#define option_name	(oa_.name)
+#define option_string	(oa_.string)
+#define option_integer	(oa_.integer)
+#define option_expect	(oa_.expect)

--- a/configure.ac
+++ b/configure.ac
@@ -15,7 +15,7 @@ AM_INIT_AUTOMAKE([foreign])
 
 # Check for pkg-config packages
 PKG_CHECK_MODULES(PIXMAN, [pixman-1 >= 0.32])
-PKG_CHECK_MODULES(XCB, [xcb-image >= 0.3.8 xcb-util >= 0.3.8])
+PKG_CHECK_MODULES(XCB, [xcb-ewmh >= 0.4.1 xcb-image >= 0.3.8 xcb-util >= 0.3.8])
 
 # Check for OpenBSD's pledge(2)
 AC_CHECK_FUNCS([pledge])

--- a/functions.h
+++ b/functions.h
@@ -56,7 +56,8 @@ o(stretch,  file,     "stretches file to fully cover output")		\
 o(tile,     file,     "tiles file repeatedly")				\
 o(trim,     geometry, "area of interest in source file")		\
 o(version,  void,     "prints version and exits")			\
-o(zoom,     file,     "zooms file to fit output with cropping")
+o(zoom,     file,     "zooms file to fit output with cropping")		\
+o(test,     void,     "prints tests and exits")
 
 enum {
 	OPTION_END = 0,

--- a/functions.h
+++ b/functions.h
@@ -39,6 +39,7 @@
 #define TARGET_ROOT	2
 
 #define OPTIONS(o)							\
+o(help,     void,     "prints help and exits")				\
 o(center,   file,     "centers the input file on the output")		\
 o(clear,    void,     "initializes screen with a black background")	\
 o(daemon,   void,     "keeps xwallpaper running in background")		\

--- a/functions.h
+++ b/functions.h
@@ -38,6 +38,35 @@
 #define TARGET_ATOMS	1
 #define TARGET_ROOT	2
 
+#define OPTIONS(o)							\
+o(center,   file,     "centers the input file on the output")		\
+o(clear,    void,     "initializes screen with a black background")	\
+o(daemon,   void,     "keeps xwallpaper running in background")		\
+o(debug,    void,     "displays debug messages on standard error")	\
+o(desktop,  number,   "desktop by its _NET_CURRENT_DESKTOP number")	\
+o(focus,    file,     "trim box guaranteed to be visible on output")	\
+o(maximize, file,     "maximizes to fit without cropping")		\
+o(no_atoms, void,     "atoms for pseudo transparency are not updated")	\
+o(no_randr, void,     "uses the whole output inputs")			\
+o(no_root,  void,     "background of the root window is not updated")	\
+o(output,   output,   "output for subsequent wallpaper files")		\
+o(screen,   number,   "screen by its screen number")			\
+o(stretch,  file,     "stretches file to fully cover output")		\
+o(tile,     file,     "tiles file repeatedly")				\
+o(trim,     geometry, "area of interest in source file")		\
+o(version,  void,     "prints version and exits")			\
+o(zoom,     file,     "zooms file to fit output with cropping")
+
+enum {
+	OPTION_END = 0,
+	OPTION_OK = 0,
+	OPTION_INVALID,
+	OPTION_MISSING,
+	OPTION_NOTNUMBER,
+#define OPTION_LABEL_ENUM(name_, arg_, desc_) OPTION_##name_,
+OPTIONS(OPTION_LABEL_ENUM)
+};
+
 #define SAFE_MUL(res, x, y) do {					 \
 	if ((y) != 0 && SIZE_MAX / (y) < (x))				 \
 		errx(1, "memory allocation would exceed system limits"); \
@@ -56,29 +85,13 @@ typedef struct wp_box {
 	uint16_t	y_off;
 } wp_box_t;
 
-typedef struct wp_buffer {
-	FILE		*fp;
-	pixman_image_t	*pixman_image;
-	dev_t		 st_dev;
-	ino_t		 st_ino;
-} wp_buffer_t;
-
-typedef struct wp_option {
-	wp_buffer_t	*buffer;
-	int		 desktop;
-	char		*filename;
-	int		 mode;
-	char		*output;
-	int		 screen;
-	wp_box_t	*trim;
-} wp_option_t;
+typedef struct wp_argcv {
+	int		  c;
+	char		**v;
+} wp_argcv_t;
 
 typedef struct wp_config {
-	wp_option_t	*options;
-	size_t		 count;
-	int		 daemon;
-	int		 source;
-	int		 target;
+	wp_argcv_t	argcv;
 } wp_config_t;
 
 typedef struct wp_output {
@@ -87,17 +100,35 @@ typedef struct wp_output {
 	uint16_t width, height;
 } wp_output_t;
 
+typedef struct wp_match {
+	int mode;
+	const char *modename;
+	const char *filename;
+
+	const char *trim;
+
+	int screen;
+	int desktop;
+	const char *output;
+} wp_match_t;
+
 extern int	 has_randr;
 extern int	 show_debug;
 
 void		 debug(const char *, ...);
-void		 free_outputs(wp_output_t *);
-wp_output_t	*get_output(wp_output_t *, char *);
 wp_output_t	*get_outputs(xcb_connection_t *, xcb_screen_t *);
 pixman_image_t	*load_jpeg(FILE *);
 pixman_image_t	*load_png(FILE *);
 pixman_image_t	*load_xpm(xcb_connection_t *, xcb_screen_t *, FILE *);
-wp_config_t	*parse_config(char **);
+int		 parse_box(const char *s, wp_box_t *box);
+wp_match_t	 option_match_wallpaper(wp_argcv_t argcv,
+			int screen, int desktop, const char *output);
+wp_config_t	 parse_config(int argc, char **argv);
 void		 stage1_sandbox(void);
 void		 stage2_sandbox(void);
 void		*xmalloc(size_t);
+
+int source_option(wp_argcv_t argcv);
+int target_option(wp_argcv_t argcv);
+int has_daemon_option(wp_argcv_t argcv);
+int has_desktop_option(wp_argcv_t argcv);

--- a/functions.h
+++ b/functions.h
@@ -65,6 +65,7 @@ typedef struct wp_buffer {
 
 typedef struct wp_option {
 	wp_buffer_t	*buffer;
+	int		 desktop;
 	char		*filename;
 	int		 mode;
 	char		*output;

--- a/main.c
+++ b/main.c
@@ -568,6 +568,12 @@ process_atoms(xcb_connection_t *c, xcb_screen_t *screen, xcb_pixmap_t *pixmap,
 	}
 }
 
+static int
+get_current_desktop()
+{
+	return -1;
+}
+
 static void
 process_screen(xcb_connection_t *c, xcb_screen_t *screen, int snum,
     wp_config_t *config)
@@ -580,12 +586,14 @@ process_screen(xcb_connection_t *c, xcb_screen_t *screen, int snum,
 	wp_option_t *opt, *options;
 	uint16_t width, height;
 	xcb_rectangle_t rectangle;
-	int created;
+	int created, dnum;
 
+	dnum = get_current_desktop();
 	options = config->options;
 
 	/* let X perform non-randr tiling if requested */
-	if (options != NULL && options[0].mode == MODE_TILE &&
+	if (options != NULL && options[0].screen == snum &&
+	    options[0].desktop == dnum && options[0].mode == MODE_TILE &&
 	    options[0].output == NULL && options[1].filename == NULL) {
 		pixman_image_t *pixman_image = options->buffer->pixman_image;
 
@@ -650,8 +658,9 @@ process_screen(xcb_connection_t *c, xcb_screen_t *screen, int snum,
 	for (opt = options; opt != NULL && opt->filename != NULL; opt++) {
 		wp_output_t *output;
 
-		/* ignore options which are not relevant for this screen */
-		if (opt->screen != -1 && opt->screen != snum)
+		/* ignore irrelevant options for this screen/desktop pair */
+		if ((opt->screen != -1 && opt->screen != snum) ||
+		    (opt->desktop != -1 && opt->desktop != dnum))
 			continue;
 
 		if (opt->output != NULL &&
@@ -701,10 +710,10 @@ usage(void)
 {
 	fprintf(stderr,
 "usage: xwallpaper [--screen <screen>] [--clear] [--daemon] [--debug]\n"
-"  [--no-atoms] [--no-randr] [--no-root] [--trim widthxheight[+x+y]]\n"
-"  [--output <output>] [--center <file>] [--focus <file>]\n"
-"  [--maximize <file>] [--stretch <file>] [--tile <file>] [--zoom <file>]\n"
-"  [--version]\n");
+"  [--desktop <desktop>] [--no-atoms] [--no-randr] [--no-root]\n"
+"  [--trim widthxheight[+x+y]] [--output <output>] [--center <file>]\n"
+"  [--focus <file>] [--maximize <file>] [--stretch <file>] [--tile <file>]\n"
+"  [--zoom <file>] [--version]\n");
 	exit(1);
 }
 
@@ -747,6 +756,17 @@ process_events(xcb_connection_t *c, wp_config_t *config)
 		process_event(config, c, event);
 }
 #endif /* WITH_RANDR */
+
+int
+has_desktop_option(wp_config_t *config)
+{
+	wp_option_t *opt;
+
+	for (opt = config->options; opt != NULL && opt->filename != NULL; opt++)
+		if (opt->desktop != -1)
+			return 1;
+	return 0;
+}
 
 int
 main(int argc, char *argv[])
@@ -809,7 +829,8 @@ main(int argc, char *argv[])
 
 #ifdef WITH_RANDR
 	if (config->daemon) {
-		if (config->daemon && has_randr == 0)
+		if (config->daemon && has_randr == 0 &&
+		    !has_desktop_option(config))
 			warnx("--daemon requires RandR");
 		else
 			process_events(c, config);

--- a/main.c
+++ b/main.c
@@ -20,6 +20,7 @@
   #include <xcb/randr.h>
 #endif /* WITH_RANDR */
 #include <xcb/xcb.h>
+#include <xcb/xcb_ewmh.h>
 #include <xcb/xcb_image.h>
 
 #include <err.h>
@@ -569,9 +570,20 @@ process_atoms(xcb_connection_t *c, xcb_screen_t *screen, xcb_pixmap_t *pixmap,
 }
 
 static int
-get_current_desktop()
+get_current_desktop(xcb_connection_t *c, int snum)
 {
-	return -1;
+	xcb_ewmh_connection_t ewmh;
+	uint32_t dnum;
+
+	if (!xcb_ewmh_init_atoms_replies(&ewmh,
+	    xcb_ewmh_init_atoms(c, &ewmh), NULL))
+		return -1;
+
+	if (!xcb_ewmh_get_current_desktop_reply(&ewmh,
+	    xcb_ewmh_get_current_desktop(&ewmh, snum), &dnum, NULL))
+		return -1;
+
+	return dnum;
 }
 
 static void
@@ -588,7 +600,7 @@ process_screen(xcb_connection_t *c, xcb_screen_t *screen, int snum,
 	xcb_rectangle_t rectangle;
 	int created, dnum;
 
-	dnum = get_current_desktop();
+	dnum = get_current_desktop(c, snum);
 	options = config->options;
 
 	/* let X perform non-randr tiling if requested */
@@ -717,9 +729,30 @@ usage(void)
 	exit(1);
 }
 
+static void
+process_desktop_event(wp_config_t *config, xcb_connection_t *c,
+    xcb_property_notify_event_t *event, xcb_atom_t cdesk)
+{
+	xcb_screen_iterator_t it;
+	int snum;
+
+	if (event->atom != cdesk)
+		return;
+
+	it = xcb_setup_roots_iterator(xcb_get_setup(c));
+	for (snum = 0; it.rem; snum++, xcb_screen_next(&it))
+		if (it.data->root == event->window) {
+			process_screen(c, it.data, snum, config);
+			break;
+		}
+
+	if (xcb_connection_has_error(c))
+		warnx("error encountered while setting wallpaper");
+}
+
 #ifdef WITH_RANDR
 static void
-process_event(wp_config_t *config, xcb_connection_t *c,
+process_randr_event(wp_config_t *config, xcb_connection_t *c,
     xcb_generic_event_t *event) {
 	xcb_randr_screen_change_notify_event_t *randr_event;
 	xcb_screen_iterator_t it;
@@ -739,22 +772,6 @@ process_event(wp_config_t *config, xcb_connection_t *c,
 	if (xcb_connection_has_error(c))
 		warnx("error encountered while setting wallpaper");
 }
-
-static void
-process_events(xcb_connection_t *c, wp_config_t *config)
-{
-	xcb_screen_iterator_t it = xcb_setup_roots_iterator(xcb_get_setup(c));
-	xcb_generic_event_t *event;
-	int snum;
-
-	for (snum = 0; it.rem; snum++, xcb_screen_next(&it))
-		xcb_request_check(c, xcb_randr_select_input(c,
-		    it.data->root,
-		    XCB_RANDR_NOTIFY_MASK_SCREEN_CHANGE));
-
-	while ((event = xcb_wait_for_event(c)) != NULL)
-		process_event(config, c, event);
-}
 #endif /* WITH_RANDR */
 
 int
@@ -766,6 +783,61 @@ has_desktop_option(wp_config_t *config)
 		if (opt->desktop != -1)
 			return 1;
 	return 0;
+}
+
+static void
+process_events(xcb_connection_t *c, wp_config_t *config)
+{
+	xcb_screen_iterator_t it = xcb_setup_roots_iterator(xcb_get_setup(c));
+	xcb_generic_event_t *event;
+	xcb_atom_t cdesk;
+	int snum;
+
+	for (snum = 0; it.rem; snum++, xcb_screen_next(&it)) {
+#ifdef WITH_RANDR
+		if (has_randr == 1)
+			xcb_request_check(c, xcb_randr_select_input(c,
+			    it.data->root,
+			    XCB_RANDR_NOTIFY_MASK_SCREEN_CHANGE));
+#endif /* WITH_RANDR */
+		if (has_desktop_option(config)) {
+			const char *name = "_NET_CURRENT_DESKTOP";
+			xcb_intern_atom_cookie_t cookie;
+			xcb_intern_atom_reply_t *reply;
+
+			cookie = xcb_intern_atom(c, 0, strlen(name), name);
+			reply = xcb_intern_atom_reply(c, cookie, NULL);
+
+			if (reply != NULL) {
+				uint32_t pchange[] = {
+				    XCB_EVENT_MASK_PROPERTY_CHANGE
+				};
+
+				cdesk = reply->atom;
+				free(reply);
+
+				xcb_request_check(c,
+				    xcb_change_window_attributes_checked(c,
+				    it.data->root, XCB_CW_EVENT_MASK, pchange));
+			}
+		}
+	}
+
+	while ((event = xcb_wait_for_event(c)) != NULL) {
+		switch (event->response_type) {
+		case XCB_PROPERTY_NOTIFY:
+			process_desktop_event(config, c,
+			    (xcb_property_notify_event_t *) event, cdesk);
+			break;
+#ifdef WITH_RANDR
+		case XCB_RANDR_SCREEN_CHANGE_NOTIFY:
+			process_randr_event(config, c, event);
+			break;
+#endif /* WITH_RANDR */
+		default:
+			break;
+		}
+	}
 }
 
 int
@@ -827,15 +899,13 @@ main(int argc, char *argv[])
 	if (xcb_connection_has_error(c))
 		warnx("error encountered while setting wallpaper");
 
-#ifdef WITH_RANDR
 	if (config->daemon) {
 		if (config->daemon && has_randr == 0 &&
 		    !has_desktop_option(config))
-			warnx("--daemon requires RandR");
+			warnx("--daemon requires --desktop or RandR");
 		else
 			process_events(c, config);
 	}
-#endif /* WITH_RANDR */
 
 	xcb_disconnect(c);
 

--- a/main.c
+++ b/main.c
@@ -66,89 +66,82 @@ get_max_rows_per_request(xcb_connection_t *c, xcb_image_t *image, uint32_t n)
 }
 
 static pixman_image_t *
-load_pixman_image(xcb_connection_t *c, xcb_screen_t *screen, FILE *fp)
+load_pixman_image(xcb_connection_t *c, xcb_screen_t *screen,
+    wp_match_t match, wp_config_t *config)
 {
-	pixman_image_t *pixman_image;
+	pixman_image_t *img = NULL;
+	int height, width;
+	wp_box_t box;
 
-	pixman_image = NULL;
+	FILE *fp = fopen(match.filename, "rb");
+	if (!fp)
+		err(1, "open '%s' failed", match.filename);
+
+	debug("loading %s\n", match.filename);
 
 #ifdef WITH_PNG
-	if (pixman_image == NULL) {
+	if (img == NULL) {
 		rewind(fp);
-		pixman_image = load_png(fp);
+		img = load_png(fp);
 	}
 #endif /* WITH_PNG */
 #ifdef WITH_JPEG
-	if (pixman_image == NULL) {
+	if (img == NULL) {
 		rewind(fp);
-		pixman_image = load_jpeg(fp);
+		img = load_jpeg(fp);
 	}
 #endif /* WITH_JPEG */
 #ifdef WITH_XPM
-	if (pixman_image == NULL) {
+	if (img == NULL) {
 		rewind(fp);
-		pixman_image = load_xpm(c, screen, fp);
+		img = load_xpm(c, screen, fp);
 	}
 #endif /* WITH_XPM */
 
-	return pixman_image;
+	if (img == NULL)
+		errx(1, "failed to parse %s", match.filename);
+	fclose(fp);
+
+	height = pixman_image_get_height(img);
+	width = pixman_image_get_width(img);
+
+	if (height > UINT16_MAX || width > UINT16_MAX)
+		errx(1, "%s has illegal dimensions", match.filename);
+
+	if (match.trim != NULL && parse_box(match.trim, &box)) {
+		if (height < box.y_off + box.height ||
+		    width < box.x_off + box.width)
+			errx(1, "%s is smaller than trim box", match.filename);
+	}
+
+	return img;
 }
 
 static void
-load_pixman_images(xcb_connection_t *c, xcb_screen_t *screen,
-    wp_option_t *options)
-{
-	wp_option_t *opt;
-	pixman_image_t *img;
-
-	for (opt = options; opt != NULL && opt->filename != NULL; opt++)
-		if (opt->buffer->pixman_image == NULL) {
-			int height, width;
-
-			debug("loading %s\n", opt->filename);
-			img = load_pixman_image(c, screen, opt->buffer->fp);
-			if (img == NULL)
-				errx(1, "failed to parse %s", opt->filename);
-			opt->buffer->pixman_image = img;
-			fclose(opt->buffer->fp);
-
-			height = pixman_image_get_height(img);
-			width = pixman_image_get_width(img);
-
-			if (height > UINT16_MAX || width > UINT16_MAX)
-				errx(1, "%s has illegal dimensions",
-				    opt->filename);
-
-			if (opt->trim != NULL) {
-				wp_box_t *trim = opt->trim;
-
-				if (height < trim->y_off + trim->height ||
-				    width < trim->x_off + trim->width)
-					errx(1, "%s is smaller than trim box",
-					    opt->filename);
-			}
-		}
-}
-
-static void
-tile(pixman_image_t *dest, wp_output_t *output, wp_option_t *option)
+tile(xcb_connection_t *c, xcb_screen_t *screen, wp_config_t *config,
+	pixman_image_t *dest, wp_output_t *output, wp_match_t match)
 {
 	pixman_image_t *pixman_image;
 	int src_width, src_height, src_x, src_y;
 	uint16_t off_x, off_y;
 
-	pixman_image = option->buffer->pixman_image;
+	pixman_image = load_pixman_image(c, screen, match, config);
 
-	if (option->trim == NULL) {
+	if (match.trim == NULL) {
 		src_width = pixman_image_get_width(pixman_image);
 		src_height = pixman_image_get_height(pixman_image);
 		src_x = 0;
 		src_y = 0;
 	} else {
-		src_width = option->trim->width;
-		src_height = option->trim->height;
-		src_x = option->trim->x_off;
-		src_y = option->trim->y_off;
+		wp_box_t box;
+
+		if (!parse_box(match.trim, &box))
+			errx(EXIT_FAILURE, "invalid trim box: %s\n", match.trim);
+
+		src_width = box.width;
+		src_height = box.height;
+		src_x = box.x_off;
+		src_y = box.y_off;
 	}
 
 	/* reset transformation and filter of transform calls */
@@ -177,7 +170,7 @@ tile(pixman_image_t *dest, wp_output_t *output, wp_option_t *option)
 				w = src_width;
 
 			debug("tiling %s for %s (area %dx%d+%d+%d)\n",
-			    option->filename, output->name != NULL ?
+			    match.filename, output->name != NULL ?
 			    output->name : "screen", w, h, off_x, off_y);
 			pixman_image_composite(PIXMAN_OP_CONJOINT_SRC,
 			    pixman_image, NULL, dest, src_x, src_y, 0, 0,
@@ -187,7 +180,8 @@ tile(pixman_image_t *dest, wp_output_t *output, wp_option_t *option)
 }
 
 static void
-transform(pixman_image_t *dest, wp_output_t *output, wp_option_t *option,
+transform(xcb_connection_t *c, xcb_screen_t *screen, wp_config_t *config,
+    pixman_image_t *dest, wp_output_t *output, wp_match_t match,
     pixman_filter_t filter)
 {
 	pixman_image_t *pixman_image;
@@ -201,23 +195,28 @@ transform(pixman_image_t *dest, wp_output_t *output, wp_option_t *option,
 	float translate_x, translate_y;
 	float off_x, off_y;
 
-	mode = option->mode;
-	pixman_image = option->buffer->pixman_image;
+	mode = match.mode;
+	pixman_image = load_pixman_image(c, screen, match, config);
 	pix_width = pixman_image_get_width(pixman_image);
 	pix_height = pixman_image_get_height(pixman_image);
 	xcb_width = output->width;
 	xcb_height = output->height;
 
-	if (option->trim == NULL) {
+	if (match.trim == NULL) {
 		src_width = pix_width;
 		src_height = pix_height;
 		off_x = 0;
 		off_y = 0;
 	} else {
-		src_width = option->trim->width;
-		src_height = option->trim->height;
-		off_x = (float)option->trim->x_off;
-		off_y = (float)option->trim->y_off;
+		wp_box_t box;
+
+		if (!parse_box(match.trim, &box))
+			errx(EXIT_FAILURE, "invalid trim box: %s\n", match.trim);
+
+		src_width = box.width;
+		src_height = box.height;
+		off_x = box.x_off;
+		off_y = box.y_off;
 	}
 
 	if (mode == MODE_FOCUS) {
@@ -358,15 +357,15 @@ transform(pixman_image_t *dest, wp_output_t *output, wp_option_t *option,
 
 	pixman_f_transform_init_translate(&ftransform,
 	    translate_x, translate_y);
-	if (option->mode != MODE_CENTER)
+	if (match.mode != OPTION_center)
 		pixman_f_transform_scale(&ftransform, NULL, w_scale, h_scale);
 	pixman_image_set_filter(pixman_image, filter, NULL, 0);
 	pixman_transform_from_pixman_f_transform(&transform, &ftransform);
 	pixman_image_set_transform(pixman_image, &transform);
 
 	debug("composing %s for %s (area %dx%d+%d+%d) (mode %d)\n",
-	    option->filename, output->name != NULL ? output->name : "screen",
-	    output->width, output->height, 0, 0, option->mode);
+	    match.filename, output->name != NULL ? output->name : "screen",
+	    output->width, output->height, 0, 0, match.mode);
 	pixman_image_composite(PIXMAN_OP_CONJOINT_SRC, pixman_image, NULL, dest,
 	    0, 0, 0, 0, 0, 0, output->width, output->height);
 }
@@ -437,8 +436,9 @@ put_wallpaper(xcb_connection_t *c, xcb_screen_t *screen, wp_output_t *output,
 }
 
 static void
-process_output(xcb_connection_t *c, xcb_screen_t *screen, wp_output_t *output,
-    wp_option_t *option, xcb_pixmap_t pixmap, xcb_gcontext_t gc)
+process_output(xcb_connection_t *c, xcb_screen_t *screen, wp_config_t *config,
+    wp_output_t *output, wp_match_t match, xcb_pixmap_t pixmap,
+    xcb_gcontext_t gc)
 {
 	uint32_t *pixels;
 	size_t len, stride;
@@ -473,10 +473,10 @@ process_output(xcb_connection_t *c, xcb_screen_t *screen, wp_output_t *output,
 	if (pixman_image == NULL)
 		errx(1, "failed to create temporary pixman image");
 
-	if (option->mode == MODE_TILE)
-		tile(pixman_image, output, option);
+	if (match.mode == OPTION_tile)
+		tile(c, screen, config, pixman_image, output, match);
 	else
-		transform(pixman_image, output, option, filter);
+		transform(c, screen, config, pixman_image, output, match, filter);
 
 	xcb_image = xcb_image_create_native(c, output->width, output->height,
 	    XCB_IMAGE_FORMAT_Z_PIXMAP, depth, NULL, len, (uint8_t *) pixels);
@@ -594,15 +594,14 @@ process_screen(xcb_connection_t *c, xcb_screen_t *screen, int snum,
 	xcb_gcontext_t gc;
 	xcb_get_geometry_cookie_t geom_cookie;
 	xcb_get_geometry_reply_t *geom_reply;
-	wp_output_t *outputs, tile_output;
-	wp_option_t *opt, *options;
+	wp_output_t *output, *outputs, tile_output;
 	uint16_t width, height;
 	xcb_rectangle_t rectangle;
 	int created, dnum;
 
 	dnum = get_current_desktop(c, snum);
-	options = config->options;
 
+#if 0 // FIXME
 	/* let X perform non-randr tiling if requested */
 	if (options != NULL && options[0].screen == snum &&
 	    options[0].desktop == dnum && options[0].mode == MODE_TILE &&
@@ -621,12 +620,15 @@ process_screen(xcb_connection_t *c, xcb_screen_t *screen, int snum,
 		};
 		outputs = &tile_output;
 	} else {
+#endif
 		width = screen->width_in_pixels;
 		height = screen->height_in_pixels;
 		outputs = get_outputs(c, screen);
+#if 0 // FIXME
 	}
+#endif
 
-	if (config->source == SOURCE_ATOMS) {
+	if (source_option(config->argcv) == SOURCE_ATOMS) {
 		process_atoms(c, screen, NULL, &pixmap);
 		if (pixmap != XCB_BACK_PIXMAP_NONE) {
 			geom_cookie = xcb_get_geometry(c, pixmap);
@@ -644,7 +646,8 @@ process_screen(xcb_connection_t *c, xcb_screen_t *screen, int snum,
 		debug("creating pixmap (%dx%d)\n", width, height);
 		pixmap = xcb_generate_id(c);
 #ifdef WITH_RANDR
-		if (config->daemon && (config->target & TARGET_ATOMS) &&
+		if (has_daemon_option(config->argcv) &&
+		    (target_option(config->argcv) & TARGET_ATOMS) &&
 		    !xcb_connection_has_error(c))
 			created_pixmap = pixmap;
 #endif /* WITH_RANDR */
@@ -667,34 +670,27 @@ process_screen(xcb_connection_t *c, xcb_screen_t *screen, int snum,
 		created = 0;
 	}
 
-	for (opt = options; opt != NULL && opt->filename != NULL; opt++) {
-		wp_output_t *output;
+	for (output = outputs; output->name != NULL; output++) {
+		wp_match_t match = option_match_wallpaper(config->argcv,
+			snum, dnum, output->name);
 
-		/* ignore irrelevant options for this screen/desktop pair */
-		if ((opt->screen != -1 && opt->screen != snum) ||
-		    (opt->desktop != -1 && opt->desktop != dnum))
+		if (!match.filename)
 			continue;
 
-		if (opt->output != NULL &&
-		    strcmp(opt->output, "all") == 0)
-			for (output = outputs; output->name != NULL; output++)
-				process_output(c, screen, output, opt,
-				    pixmap, gc);
-		else {
-			output = get_output(outputs, opt->output);
-			if (output != NULL)
-				process_output(c, screen, output, opt,
-				    pixmap, gc);
-		}
+		process_output(c, screen, config, output, match, pixmap, gc);
 	}
 
+#if 0 // FIXME
 	if (options == NULL)
 		result = XCB_BACK_PIXMAP_NONE;
 	else
 		result = pixmap;
+#else
+	result = pixmap;
+#endif
 
 	xcb_free_gc(c, gc);
-	if (config->target & TARGET_ROOT) {
+	if (target_option(config->argcv) & TARGET_ROOT) {
 		/* always set a pixmap, even before clearing */
 		xcb_change_window_attributes(c, screen->root,
 		    XCB_CW_BACK_PIXMAP, &pixmap);
@@ -704,7 +700,7 @@ process_screen(xcb_connection_t *c, xcb_screen_t *screen, int snum,
 			xcb_free_pixmap(c, pixmap);
 		}
 	}
-	if (config->target & TARGET_ATOMS) {
+	if (target_option(config->argcv) & TARGET_ATOMS) {
 		process_atoms(c, screen, &result, NULL);
 		if (created)
 			xcb_set_close_down_mode(c,
@@ -712,21 +708,6 @@ process_screen(xcb_connection_t *c, xcb_screen_t *screen, int snum,
 	} else
 		xcb_free_pixmap(c, pixmap);
 	xcb_request_check(c, xcb_clear_area(c, 0, screen->root, 0, 0, 0, 0));
-
-	if (outputs != &tile_output)
-		free_outputs(outputs);
-}
-
-static void
-usage(void)
-{
-	fprintf(stderr,
-"usage: xwallpaper [--screen <screen>] [--clear] [--daemon] [--debug]\n"
-"  [--desktop <desktop>] [--no-atoms] [--no-randr] [--no-root]\n"
-"  [--trim widthxheight[+x+y]] [--output <output>] [--center <file>]\n"
-"  [--focus <file>] [--maximize <file>] [--stretch <file>] [--tile <file>]\n"
-"  [--zoom <file>] [--version]\n");
-	exit(1);
 }
 
 static void
@@ -774,17 +755,6 @@ process_randr_event(wp_config_t *config, xcb_connection_t *c,
 }
 #endif /* WITH_RANDR */
 
-int
-has_desktop_option(wp_config_t *config)
-{
-	wp_option_t *opt;
-
-	for (opt = config->options; opt != NULL && opt->filename != NULL; opt++)
-		if (opt->desktop != -1)
-			return 1;
-	return 0;
-}
-
 static void
 process_events(xcb_connection_t *c, wp_config_t *config)
 {
@@ -800,7 +770,7 @@ process_events(xcb_connection_t *c, wp_config_t *config)
 			    it.data->root,
 			    XCB_RANDR_NOTIFY_MASK_SCREEN_CHANGE));
 #endif /* WITH_RANDR */
-		if (has_desktop_option(config)) {
+		if (has_desktop_option(config->argcv)) {
 			const char *name = "_NET_CURRENT_DESKTOP";
 			xcb_intern_atom_cookie_t cookie;
 			xcb_intern_atom_reply_t *reply;
@@ -843,7 +813,7 @@ process_events(xcb_connection_t *c, wp_config_t *config)
 int
 main(int argc, char *argv[])
 {
-	wp_config_t *config;
+	wp_config_t config;
 	xcb_connection_t *c;
 #ifdef WITH_RANDR
 	xcb_connection_t *c2;
@@ -857,17 +827,17 @@ main(int argc, char *argv[])
 #ifdef WITH_SECCOMP
 	stage1_sandbox();
 #endif /* WITH_SECCOMP */
-	if (argc < 2 || (config = parse_config(++argv)) == NULL)
-		usage();
 
-	if (config->daemon && daemon(0, show_debug) < 0)
+	config = parse_config(argc, argv);
+
+	if (has_daemon_option(config.argcv) && daemon(0, show_debug) < 0)
 		warnx("failed to daemonize");
 
 	c = xcb_connect(NULL, NULL);
 	if (xcb_connection_has_error(c))
 		errx(1, "failed to connect to X server");
 #ifdef WITH_RANDR
-	if (config->daemon) {
+	if (has_daemon_option(config.argcv)) {
 		c2 = xcb_connect(NULL, NULL);
 		if (xcb_connection_has_error(c2))
 			errx(1, "failed to connect to X server for clean up");
@@ -891,26 +861,24 @@ main(int argc, char *argv[])
 	 */
 	if (it.rem == 0)
 		errx(1, "no screen found");
-	load_pixman_images(c, it.data, config->options);
 
 	for (snum = 0; it.rem; snum++, xcb_screen_next(&it))
-		process_screen(c, it.data, snum, config);
+		process_screen(c, it.data, snum, &config);
 
 	if (xcb_connection_has_error(c))
 		warnx("error encountered while setting wallpaper");
 
-	if (config->daemon) {
-		if (config->daemon && has_randr == 0 &&
-		    !has_desktop_option(config))
+	if (has_daemon_option(config.argcv)) {
+		if (has_randr == 0 && !has_desktop_option(config.argcv))
 			warnx("--daemon requires --desktop or RandR");
 		else
-			process_events(c, config);
+			process_events(c, &config);
 	}
 
 	xcb_disconnect(c);
 
 #ifdef WITH_RANDR
-	if (config->daemon) {
+	if (has_daemon_option(config.argcv)) {
 		if (created_pixmap != XCB_BACK_PIXMAP_NONE) {
 			debug("killing X client\n");
 			xcb_request_check(c2,

--- a/options.c
+++ b/options.c
@@ -140,7 +140,7 @@ parse_int(char *string)
 
 	value = strtol(string, &endptr, 10);
 	if (endptr == string || *endptr != '\0' || value < 0 || value > INT_MAX)
-		errx(1, "failed to parse screen number: %s", string);
+		errx(1, "failed to parse number: %s", string);
 	return value;
 }
 
@@ -173,6 +173,15 @@ parse_box(char *s, wp_box_t **box)
 	return 0;
 }
 
+static int
+parse_desktop(char *s)
+{
+	if (strcmp(s, "all") == 0)
+		return -1;
+	/* return parse_int(s); */
+	return -1;
+}
+
 wp_config_t *
 parse_config(char **argv)
 {
@@ -188,7 +197,10 @@ parse_config(char **argv)
 		.target = TARGET_ATOMS | TARGET_ROOT
 	};
 
-	last = (wp_option_t){ .screen = -1 };
+	last = (wp_option_t){
+		.desktop = -1,
+		.screen = -1
+	};
 
 	while (*argv != NULL) {
 		if (strcmp(argv[0], "--daemon") == 0) {
@@ -197,7 +209,18 @@ parse_config(char **argv)
 			show_debug = 1;
 		else if (strcmp(argv[0], "--clear") == 0)
 			config->source = 0;
-		else if (strcmp(argv[0], "--no-atoms") == 0) {
+		else if (strcmp(argv[0], "--desktop") == 0) {
+			if (*++argv == NULL) {
+				warnx("missing argument for --desktop");
+				return NULL;
+			}
+			add_option(config, last);
+			last.desktop = parse_desktop(*argv);
+			last.filename = NULL;
+			last.mode = 0;
+			last.output = NULL;
+			last.trim = NULL;
+		} else if (strcmp(argv[0], "--no-atoms") == 0) {
 			config->target &= ~TARGET_ATOMS;
 			if (config->target == 0) {
 				warnx("--no-atoms conflicts with --no-root");
@@ -215,6 +238,7 @@ parse_config(char **argv)
 				return NULL;
 			}
 			add_option(config, last);
+			last.desktop = -1;
 			last.filename = NULL;
 			last.mode = 0;
 			last.output = NULL;

--- a/options.c
+++ b/options.c
@@ -74,6 +74,7 @@ optparse_number(struct optarg *oa)
 		return 0;						\
 	}
 
+OPTION_PREDICATE(help)
 OPTION_PREDICATE(clear)
 OPTION_PREDICATE(daemon)
 OPTION_PREDICATE(debug)
@@ -213,13 +214,16 @@ option_verify(wp_argcv_t argcv)
 		case OPTION_OK:
 			continue;
 		case OPTION_INVALID:
-			errx(EXIT_FAILURE, "invalid option: %s\n",
+			errx(EXIT_FAILURE, "invalid option: %s\n"
+				"Try the '--help' option for usage.\n",
 				option_name);
 		case OPTION_MISSING:
-			errx(EXIT_FAILURE, "%s: missing argument, expected <%s>\n",
+			errx(EXIT_FAILURE, "%s: missing argument, expected <%s>\n"
+				"Try the '--help' option for usage.\n",
 				option_name, option_expect);
 		case OPTION_NOTNUMBER:
-			errx(EXIT_FAILURE, "%s: argument not a number: %s\n",
+			errx(EXIT_FAILURE, "%s: argument not a number: %s\n"
+				"Try the '--help' option for usage.\n",
 				option_name, option_string);
 		default:
 			errx(EXIT_FAILURE, "unknown error\n");
@@ -229,10 +233,28 @@ option_verify(wp_argcv_t argcv)
 		errx(EXIT_FAILURE, "--daemon requires RandR\n");
 }
 
+static void
+help(void)
+{
+	printf("usage: xwallpaper [options]...\n\noptions:\n\n");
+
+#define OPTION_HELP(name_, arg_, desc_)					\
+	if (strcmp(#arg_, "void") == 0)					\
+		printf("  %-21s  %s\n", opt(#name_).s, desc_);		\
+	else								\
+		printf("  %-10s %-10s  %s\n", opt(#name_).s, "<"#arg_">", desc_);
+OPTIONS(OPTION_HELP)
+
+	exit(EXIT_SUCCESS);
+}
+
 wp_config_t
 parse_config(int argc, char **argv)
 {
 	wp_argcv_t argcv = { .c = argc, .v = argv };
+
+	if (has_help_option(argcv))
+		help();
 
 	if (has_version_option(argcv)) {
 		puts(VERSION);

--- a/options.c
+++ b/options.c
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2025 Tobias Stoeckmann <tobias@stoeckmann.org>
+ * Copyright (c) 2026 Fredrik Noring
  *
  * Permission to use, copy, modify, and distribute this software for any
  * purpose with or without fee is hereby granted, provided that the above
@@ -14,12 +15,7 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  */
 
-#include <sys/types.h>
-#include <sys/stat.h>
-
-#include <err.h>
 #include <limits.h>
-#include <pixman.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -28,124 +24,89 @@
 #include "config.h"
 #include "functions.h"
 
-static size_t
-add_buffer(wp_buffer_t **bufs, size_t *count, wp_buffer_t buf)
-{
-	size_t i;
+enum {
+#define OPTION_ARG_ENUM(name_, arg_, desc_) OPTION_ARG_##name_,
+OPTIONS(OPTION_ARG_ENUM)
+};
 
-	for (i = 0; i < *count; i++)
-		if ((*bufs)[i].st_dev == buf.st_dev &&
-		    (*bufs)[i].st_ino == buf.st_ino)
-			break;
+struct optarg;
 
-	if (*count != 0 && i != *count)
-		fclose(buf.fp);
-	else {
-		*bufs = realloc(*bufs, (*count + 1) * sizeof(**bufs));
-		if (*bufs == NULL)
-			err(1, "failed to allocate memory");
-		(*bufs)[(*count)++] = buf;
-	}
+static void optparse_string(struct optarg *oa);
+static void optparse_number(struct optarg *oa);
 
-	return i;
-}
+#define optparse_file		optparse_string
+#define optparse_output		optparse_string
+#define optparse_geometry	optparse_string
+
+#include "argparse.h"
 
 static void
-add_option(wp_config_t *config, wp_option_t option)
-{
-	size_t i;
-	wp_option_t *o;
-
-	if (option.filename == NULL)
-		return;
-
-	for (i = 0; i < config->count; i++)
-		if (config->options[i].output != NULL &&
-		    strcmp(config->options[i].output, option.output) == 0 &&
-		    config->options[i].screen == option.screen)
-			break;
-
-	if (i != config->count)
-		o = config->options + i;
-	else {
-		config->options = realloc(config->options,
-		    (config->count + 2) * sizeof(*config->options));
-		if (config->options == NULL)
-			err(1, "failed to allocate memory");
-		o = &config->options[config->count++];
-		config->options[config->count].filename = NULL;
-	}
-	*o = option;
-}
-
-static void
-init_buffers(wp_config_t *config)
-{
-	wp_buffer_t *buffers, buffer;
-	size_t buffers_count, i, len;
-	size_t *refs;
-
-	if (config->count == 0)
-		return;
-
-	SAFE_MUL(len, config->count, sizeof(*refs));
-	refs = xmalloc(len);
-
-	buffers = NULL;
-	buffers_count = 0;
-	buffer = (wp_buffer_t){ 0 };
-
-	for (i = 0; i < config->count; i++) {
-		struct stat st;
-
-		if ((buffer.fp = fopen(config->options[i].filename, "rb"))
-		    == NULL)
-			err(1, "open '%s' failed", config->options[i].filename);
-		if (fstat(fileno(buffer.fp), &st))
-			err(1, "stat '%s' failed", config->options[i].filename);
-		buffer.st_dev = st.st_dev;
-		buffer.st_ino = st.st_ino;
-
-		refs[i] = add_buffer(&buffers, &buffers_count, buffer);
-	}
-
-	for (i = 0; i < config->count; i++)
-		config->options[i].buffer = &buffers[refs[i]];
-	free(refs);
-}
-
-static int
-parse_mode(char *mode)
-{
-	if (strcmp(mode, "--center") == 0)
-		return MODE_CENTER;
-	if (strcmp(mode, "--focus") == 0)
-		return MODE_FOCUS;
-	if (strcmp(mode, "--maximize") == 0)
-		return MODE_MAXIMIZE;
-	if (strcmp(mode, "--stretch") == 0)
-		return MODE_STRETCH;
-	if (strcmp(mode, "--tile") == 0)
-		return MODE_TILE;
-	if (strcmp(mode, "--zoom") == 0)
-		return MODE_ZOOM;
-	return -1;
-}
-
-static int
-parse_int(char *string)
+optparse_number(struct optarg *oa)
 {
 	char *endptr;
 	long value;
 
-	value = strtol(string, &endptr, 10);
-	if (endptr == string || *endptr != '\0' || value < 0 || value > INT_MAX)
-		errx(1, "failed to parse number: %s", string);
-	return value;
+	optparse_string(oa);
+
+	if (oa->error)
+		return;
+
+	if (strcmp(oa->string, "all") == 0) {
+		oa->integer = -1;	/* "all" is a special keyword for -1 */
+		return;
+	}
+
+	value = strtol(oa->string, &endptr, 10);
+
+	if (endptr == oa->string || *endptr != '\0' ||
+			value < 0 || value > INT_MAX)
+		oa->error = OPTION_NOTNUMBER;
+
+	oa->integer = value;
 }
 
-static int
-parse_box(char *s, wp_box_t **box)
+#define OPTION_PREDICATE(name_)						\
+	int has_##name_##_option(wp_argcv_t argcv)			\
+	{								\
+		for_each_option (argcv)					\
+			if (option_label == OPTION_##name_)		\
+				return 1;				\
+		return 0;						\
+	}
+
+OPTION_PREDICATE(clear)
+OPTION_PREDICATE(daemon)
+OPTION_PREDICATE(debug)
+OPTION_PREDICATE(no_atoms)
+OPTION_PREDICATE(no_randr)
+OPTION_PREDICATE(no_root)
+OPTION_PREDICATE(version)
+
+int
+source_option(wp_argcv_t argcv)
+{
+	return !has_clear_option(argcv) && !has_no_atoms_option(argcv);
+}
+
+int
+target_option(wp_argcv_t argcv)
+{
+	return (!has_no_atoms_option(argcv) ? TARGET_ATOMS : 0) |
+	       (!has_no_root_option(argcv)  ? TARGET_ROOT  : 0);
+}
+
+int
+has_desktop_option(wp_argcv_t argcv)
+{
+	for_each_option (argcv)
+		if (option_label == OPTION_desktop)
+			return 1;
+
+	return 0;
+}
+
+int
+parse_box(const char *s, wp_box_t *box)
 {
 	wp_box_t b;
 
@@ -158,148 +119,130 @@ parse_box(char *s, wp_box_t **box)
 	case 4:
 		break;
 	default:
-		return 1;
+		return 0;
 		/* NOTREACHED */
 	}
 
 	if (UINT16_MAX - b.width < b.x_off ||
 	    UINT16_MAX - b.height < b.y_off ||
 	    b.width == 0 || b.height == 0)
+		return 0;
+
+	*box = b;
+
+	return 1;
+}
+
+static
+int screen_desktop_output_match(wp_match_t m,
+	int screen, int desktop, const char *output)
+{
+	/* -1 acts as a match "all" wildcard for screen and desktop */
+
+	if (m.screen >= 0 && screen >= 0 && m.screen != screen)
+		return 0;
+
+	if (m.desktop >= 0 && desktop >= 0 && m.desktop != desktop)
+		return 0;
+
+	if (strcmp(m.output, "all") == 0 || strcmp(output, "all") == 0)
 		return 1;
 
-	*box = xmalloc(sizeof(*box));
-	**box = b;
-
-	return 0;
+	return strcmp(m.output, output) == 0;
 }
 
-static int
-parse_desktop(char *s)
+wp_match_t
+option_match_wallpaper(wp_argcv_t argcv,
+	int screen, int desktop, const char *output)
 {
-	if (strcmp(s, "all") == 0)
-		return -1;
-	return parse_int(s);
-}
-
-wp_config_t *
-parse_config(char **argv)
-{
-	wp_config_t *config;
-	wp_option_t last;
-
-	config = xmalloc(sizeof(*config));
-	*config = (wp_config_t){
-		.options = NULL,
-		.count = 0,
-		.daemon = 0,
-		.source = SOURCE_ATOMS,
-		.target = TARGET_ATOMS | TARGET_ROOT
-	};
-
-	last = (wp_option_t){
+	wp_match_t m = {
+		.screen = -1,
 		.desktop = -1,
-		.screen = -1
+		.output = "all",
 	};
+	wp_match_t best = m;
 
-	while (*argv != NULL) {
-		if (strcmp(argv[0], "--daemon") == 0) {
-			config->daemon = 1;
-		} else if (strcmp(argv[0], "--debug") == 0)
-			show_debug = 1;
-		else if (strcmp(argv[0], "--clear") == 0)
-			config->source = 0;
-		else if (strcmp(argv[0], "--desktop") == 0) {
-			if (*++argv == NULL) {
-				warnx("missing argument for --desktop");
-				return NULL;
-			}
-			add_option(config, last);
-			last.desktop = parse_desktop(*argv);
-			last.filename = NULL;
-			last.mode = 0;
-			last.output = NULL;
-			last.trim = NULL;
-		} else if (strcmp(argv[0], "--no-atoms") == 0) {
-			config->target &= ~TARGET_ATOMS;
-			if (config->target == 0) {
-				warnx("--no-atoms conflicts with --no-root");
-				return NULL;
-			}
-		} else if (strcmp(argv[0], "--no-root") == 0) {
-			config->target &= ~TARGET_ROOT;
-			if (config->target == 0) {
-				warnx("--no-root conflicts with --no-atoms");
-				return NULL;
-			}
-		} else if (strcmp(argv[0], "--screen") == 0) {
-			if (*++argv == NULL) {
-				warnx("missing argument for --screen");
-				return NULL;
-			}
-			add_option(config, last);
-			last.desktop = -1;
-			last.filename = NULL;
-			last.mode = 0;
-			last.output = NULL;
-			last.screen = parse_int(*argv);
-			last.trim = NULL;
-		} else if (strcmp(argv[0], "--output") == 0) {
-			if (*++argv == NULL) {
-				warnx("missing argument for --output");
-				return NULL;
-			}
-			if (has_randr == 0) {
-				warnx("--output requires RandR");
-				return NULL;
-			}
-			add_option(config, last);
-			last.filename = NULL;
-			last.mode = 0;
-			last.output = *argv;
-			last.trim = NULL;
-		} else if ((last.mode = parse_mode(*argv)) != -1) {
-			if (*++argv == NULL) {
-				warnx("missing argument for %s", *(argv - 1));
-				return NULL;
-			}
-			last.filename = *argv;
-		} else if (strcmp(argv[0], "--no-randr") == 0) {
-			if (config->count > 0) {
-				warnx("--no-randr conflicts with --output");
-				return NULL;
-			}
-			has_randr = 0;
-		} else if (strcmp(argv[0], "--trim") == 0) {
-			if (*++argv == NULL) {
-				warnx("missing argument for --trim");
-				return NULL;
-			}
-			last.filename = NULL;
-			last.mode = 0;
-			if (parse_box(*argv, &last.trim)) {
-				warnx("invalid trim box: %s\n", *argv);
-				return NULL;
-			}
-		} else if (strcmp(argv[0], "--version") == 0) {
-			puts(VERSION);
-			exit(0);
-		} else {
-			warnx("illegal argument: %s", *argv);
-			return NULL;
+	for_each_option (argcv)
+		switch (option_label) {
+		case OPTION_center:
+		case OPTION_focus:
+		case OPTION_maximize:
+		case OPTION_stretch:
+		case OPTION_tile:
+		case OPTION_zoom:
+			m.mode = option_label;
+			m.modename = &option_name[2];
+			m.filename = option_string;
+
+			if (screen_desktop_output_match(m,
+					screen, desktop, output))
+				best = m;
+			break;
+
+		case OPTION_trim:
+			m.trim = option_string;
+			break;
+
+		case OPTION_screen:
+			m.trim = NULL;
+			m.screen = option_integer;
+			m.desktop = -1;
+			m.output = "all";
+			break;
+
+		case OPTION_desktop:
+			m.trim = NULL;
+			m.desktop = option_integer;
+			m.output = "all";
+			break;
+
+		case OPTION_output:
+			m.trim = NULL;
+			m.output = option_string;
+			break;
 		}
-		++argv;
+
+	return best;
+}
+
+static void
+option_verify(wp_argcv_t argcv)
+{
+	for_each_option (argcv)
+		switch (option_error) {
+		case OPTION_OK:
+			continue;
+		case OPTION_INVALID:
+			errx(EXIT_FAILURE, "invalid option: %s\n",
+				option_name);
+		case OPTION_MISSING:
+			errx(EXIT_FAILURE, "%s: missing argument, expected <%s>\n",
+				option_name, option_expect);
+		case OPTION_NOTNUMBER:
+			errx(EXIT_FAILURE, "%s: argument not a number: %s\n",
+				option_name, option_string);
+		default:
+			errx(EXIT_FAILURE, "unknown error\n");
+		}
+
+	if (has_daemon_option(argcv) && !has_randr)
+		errx(EXIT_FAILURE, "--daemon requires RandR\n");
+}
+
+wp_config_t
+parse_config(int argc, char **argv)
+{
+	wp_argcv_t argcv = { .c = argc, .v = argv };
+
+	if (has_version_option(argcv)) {
+		puts(VERSION);
+		exit(EXIT_SUCCESS);
 	}
-	if (has_randr == -1 && last.output == NULL)
-		last.output = "all";
-	add_option(config, last);
 
-	if (!(config->target & TARGET_ATOMS))
-		config->source = 0;
+	if (has_no_randr_option(argcv))
+		has_randr = 0;
 
-	if (config->count == 0 && config->source != 0)
-		return NULL;
+	option_verify(argcv);
 
-	init_buffers(config);
-
-	return config;
+	return (wp_config_t) { .argcv = argcv };
 }

--- a/options.c
+++ b/options.c
@@ -82,6 +82,7 @@ OPTION_PREDICATE(no_atoms)
 OPTION_PREDICATE(no_randr)
 OPTION_PREDICATE(no_root)
 OPTION_PREDICATE(version)
+OPTION_PREDICATE(test)
 
 int
 source_option(wp_argcv_t argcv)
@@ -234,6 +235,27 @@ option_verify(wp_argcv_t argcv)
 }
 
 static void
+test(wp_argcv_t argcv)
+{
+	const char *outputs[] = { "DP", "HDMI", "VGA", NULL };
+
+        for (int screen = 0; screen <= 2; screen++)
+        for (int desktop = 0; desktop <= 4; desktop++)
+        for (int output = 0; outputs[output]; output++) {
+                const wp_match_t m = option_match_wallpaper(argcv,
+			screen, desktop, outputs[output]);
+
+                if (!m.filename)
+			continue;
+
+		printf("screen %d desktop %d output %-4s mode %-8s wallpaper %s\n",
+			screen, desktop, outputs[output], m.modename, m.filename);
+        }
+
+	exit(EXIT_SUCCESS);
+}
+
+static void
 help(void)
 {
 	printf("usage: xwallpaper [options]...\n\noptions:\n\n");
@@ -265,6 +287,9 @@ parse_config(int argc, char **argv)
 		has_randr = 0;
 
 	option_verify(argcv);
+
+	if (has_test_option(argcv))
+		test(argcv);
 
 	return (wp_config_t) { .argcv = argcv };
 }

--- a/options.c
+++ b/options.c
@@ -178,8 +178,7 @@ parse_desktop(char *s)
 {
 	if (strcmp(s, "all") == 0)
 		return -1;
-	/* return parse_int(s); */
-	return -1;
+	return parse_int(s);
 }
 
 wp_config_t *

--- a/outputs.c
+++ b/outputs.c
@@ -34,33 +34,6 @@ int has_randr = -1;
 int has_randr = 0;
 #endif /* WITH_RANDR */
 
-void
-free_outputs(wp_output_t *outputs)
-{
-	wp_output_t *output;
-
-	for (output = outputs; output->name != NULL; output++)
-		free(output->name);
-	free(outputs);
-}
-
-wp_output_t *
-get_output(wp_output_t *outputs, char *name)
-{
-	wp_output_t *output;
-
-	for (output = outputs; output->name != NULL; output++)
-		if (name != NULL && strcmp(output->name, name) == 0)
-			return output;
-
-	if (name != NULL) {
-		warnx("output %s was not found/disconnected, ignoring", name);
-		return NULL;
-	}
-
-	return output;
-}
-
 #ifdef WITH_RANDR
 static int
 check_randr(xcb_connection_t *c)

--- a/xwallpaper.1
+++ b/xwallpaper.1
@@ -70,6 +70,23 @@ Displays debug messages on the standard error output while
 is running.  If used in conjunction with
 .Fl Fl daemon
 the process will not modify the standard input and outputs.
+.It Fl Fl desktop Ar desktop
+Specifies a desktop by its _NET_CURRENT_DESKTOP property number,
+retrievable with e.g.
+.Cm xprop -root _NET_CURRENT_DESKTOP .
+The special keyword
+.Cm all
+makes the wallpaper default for all desktops for the given screen.
+If
+.Fl Fl desktop
+is used without
+.Fl Fl daemon ,
+then
+.Nm xwallpaper
+will only adjust the screen if current desktop matches the specified desktop.
+With
+.Fl Fl daemon ,
+it changes the desktop whenever the virtual desktop becomes active.
 .It Fl Fl focus Ar file
 In conjunction with
 .Fl Fl trim
@@ -164,6 +181,9 @@ Centers and recenters a JPEG file after output updates on all outputs:
 .Pp
 Tiles a JPEG file as a wallpaper on VGA-1 and zooms into a PNG file on LVDS-1:
 .Dl $ xwallpaper --output VGA-1 --tile file.jpg --output LVDS-1 --zoom file.png
+.Pp
+Special wallpaper on desktop 3:
+.Dl $ xwallpaper --daemon --zoom file.jpg --desktop 3 --zoom file.png
 .Sh BUGS
 Use the GitHub issue tracker:
 .Lk https://github.com/stoeckmann/xwallpaper/issues


### PR DESCRIPTION
The `--desktop` option updates the wallpaper when the X property [`_NET_CURRENT_DESKTOP`](https://apol.pages.freedesktop.org/xdg-specs/wm-spec/latest/ar01s03.html#idm46066816470576) changes, which happens a (virtual) desktop is switched. Example:

```
xwallpaper --daemon					\
	--output all --desktop 0 --zoom wallpaper0.jpeg	\
	--output all --desktop 1 --zoom wallpaper1.jpeg	\
	--output all --desktop 2 --zoom wallpaper2.jpeg	\
	--output all --desktop 3 --zoom wallpaper3.jpeg
```

The `xprop` command can be used to inspect `_NET_CURRENT_DESKTOP`:

```
xprop -root _NET_CURRENT_DESKTOP
```