### PR TITLE
Check --daemon/RandR dependency at later stage

### DIFF
--- a/main.c
+++ b/main.c
@@ -730,6 +730,22 @@ process_event(wp_config_t *config, xcb_connection_t *c,
 	if (xcb_connection_has_error(c))
 		warnx("error encountered while setting wallpaper");
 }
+
+static void
+process_events(xcb_connection_t *c, wp_config_t *config)
+{
+	xcb_screen_iterator_t it = xcb_setup_roots_iterator(xcb_get_setup(c));
+	xcb_generic_event_t *event;
+	int snum;
+
+	for (snum = 0; it.rem; snum++, xcb_screen_next(&it))
+		xcb_request_check(c, xcb_randr_select_input(c,
+		    it.data->root,
+		    XCB_RANDR_NOTIFY_MASK_SCREEN_CHANGE));
+
+	while ((event = xcb_wait_for_event(c)) != NULL)
+		process_event(config, c, event);
+}
 #endif /* WITH_RANDR */
 
 int
@@ -740,7 +756,6 @@ main(int argc, char *argv[])
 #ifdef WITH_RANDR
 	xcb_connection_t *c2;
 #endif /* WITH_RANDR */
-	xcb_generic_event_t *event;
 	xcb_screen_iterator_t it;
 	int snum;
 #ifdef HAVE_PLEDGE
@@ -794,14 +809,10 @@ main(int argc, char *argv[])
 
 #ifdef WITH_RANDR
 	if (config->daemon) {
-		it = xcb_setup_roots_iterator(xcb_get_setup(c));
-		for (snum = 0; it.rem; snum++, xcb_screen_next(&it))
-			xcb_request_check(c, xcb_randr_select_input(c,
-			    it.data->root,
-			    XCB_RANDR_NOTIFY_MASK_SCREEN_CHANGE));
-
-		while ((event = xcb_wait_for_event(c)) != NULL)
-			process_event(config, c, event);
+		if (config->daemon && has_randr == 0)
+			warnx("--daemon requires RandR");
+		else
+			process_events(c, config);
 	}
 #endif /* WITH_RANDR */
 

--- a/options.c
+++ b/options.c
@@ -192,10 +192,6 @@ parse_config(char **argv)
 
 	while (*argv != NULL) {
 		if (strcmp(argv[0], "--daemon") == 0) {
-			if (has_randr == 0) {
-				warnx("--daemon requires RandR");
-				return NULL;
-			}
 			config->daemon = 1;
 		} else if (strcmp(argv[0], "--debug") == 0)
 			show_debug = 1;
@@ -247,10 +243,6 @@ parse_config(char **argv)
 		} else if (strcmp(argv[0], "--no-randr") == 0) {
 			if (config->count > 0) {
 				warnx("--no-randr conflicts with --output");
-				return NULL;
-			}
-			if (config->daemon) {
-				warnx("--daemon requires RandR");
 				return NULL;
 			}
 			has_randr = 0;


### PR DESCRIPTION
It could happen that lack of RandR support is detected while setting the wallpaper for the first time. Check before entering the daemon loop to cover this case as well.

This allows setting initial wallpaper (if outputs still match) before shutting down xwallpaper, since nothing useful could be done as daemon.