### PR TITLE
Add --desktop option

### DIFF
--- a/_xwallpaper
+++ b/_xwallpaper
@@ -7,6 +7,7 @@ _arguments \
     '--clear[set background to black]' \
     '--daemon[enable daemon mode]' \
     '--debug[enable debug mode]' \
+    '*--desktop[X desktop number]:X desktop number' \
     '--no-atoms[no update of pseudo transparency atoms]' \
     '--no-randr[disable randr support]' \
     '--no-root[no update of root window background]' \

--- a/configure.ac
+++ b/configure.ac
@@ -15,7 +15,7 @@ AM_INIT_AUTOMAKE([foreign])
 
 # Check for pkg-config packages
 PKG_CHECK_MODULES(PIXMAN, [pixman-1 >= 0.32])
-PKG_CHECK_MODULES(XCB, [xcb-image >= 0.3.8 xcb-util >= 0.3.8])
+PKG_CHECK_MODULES(XCB, [xcb-ewmh >= 0.4.1 xcb-image >= 0.3.8 xcb-util >= 0.3.8])
 
 # Check for OpenBSD's pledge(2)
 AC_CHECK_FUNCS([pledge])

--- a/functions.h
+++ b/functions.h
@@ -91,6 +91,7 @@ extern int	 show_debug;
 
 void		 debug(const char *, ...);
 void		 free_outputs(wp_output_t *);
+wp_option_t	*get_option(wp_option_t *, int, const char *);
 wp_output_t	*get_output(wp_output_t *, char *);
 wp_output_t	*get_outputs(xcb_connection_t *, xcb_screen_t *);
 pixman_image_t	*load_jpeg(FILE *);

--- a/functions.h
+++ b/functions.h
@@ -65,6 +65,7 @@ typedef struct wp_buffer {
 
 typedef struct wp_option {
 	wp_buffer_t	*buffer;
+	int		 desktop;
 	char		*filename;
 	int		 mode;
 	char		*output;
@@ -91,7 +92,7 @@ extern int	 show_debug;
 
 void		 debug(const char *, ...);
 void		 free_outputs(wp_output_t *);
-wp_option_t	*get_option(wp_option_t *, int, const char *);
+wp_option_t	*get_option(wp_option_t *, int, int, const char *);
 wp_output_t	*get_output(wp_output_t *, char *);
 wp_output_t	*get_outputs(xcb_connection_t *, xcb_screen_t *);
 pixman_image_t	*load_jpeg(FILE *);

--- a/main.c
+++ b/main.c
@@ -568,6 +568,12 @@ process_atoms(xcb_connection_t *c, xcb_screen_t *screen, xcb_pixmap_t *pixmap,
 	}
 }
 
+static int
+get_current_desktop()
+{
+	return -1;
+}
+
 static void
 process_screen(xcb_connection_t *c, xcb_screen_t *screen, int snum,
     wp_config_t *config)
@@ -580,8 +586,9 @@ process_screen(xcb_connection_t *c, xcb_screen_t *screen, int snum,
 	wp_option_t *opt, *options;
 	uint16_t width, height;
 	xcb_rectangle_t rectangle;
-	int created;
+	int created, dnum;
 
+	dnum = get_current_desktop();
 	options = config->options;
 
 	/* let X perform non-randr tiling if requested */
@@ -654,7 +661,7 @@ process_screen(xcb_connection_t *c, xcb_screen_t *screen, int snum,
 	for (output = outputs; output->name != NULL; output++) {
 		wp_option_t *opt;
 
-		opt = get_option(options, snum, output->name);
+		opt = get_option(options, snum, dnum, output->name);
 		if (opt == NULL)
 			continue;
 
@@ -695,10 +702,10 @@ usage(void)
 {
 	fprintf(stderr,
 "usage: xwallpaper [--screen <screen>] [--clear] [--daemon] [--debug]\n"
-"  [--no-atoms] [--no-randr] [--no-root] [--trim widthxheight[+x+y]]\n"
-"  [--output <output>] [--center <file>] [--focus <file>]\n"
-"  [--maximize <file>] [--stretch <file>] [--tile <file>] [--zoom <file>]\n"
-"  [--version]\n");
+"  [--desktop <desktop>] [--no-atoms] [--no-randr] [--no-root]\n"
+"  [--trim widthxheight[+x+y]] [--output <output>] [--center <file>]\n"
+"  [--focus <file>] [--maximize <file>] [--stretch <file>] [--tile <file>]\n"
+"  [--zoom <file>] [--version]\n");
 	exit(1);
 }
 
@@ -741,6 +748,17 @@ process_events(xcb_connection_t *c, wp_config_t *config)
 		process_event(config, c, event);
 }
 #endif /* WITH_RANDR */
+
+int
+has_desktop_option(wp_config_t *config)
+{
+	wp_option_t *opt;
+
+	for (opt = config->options; opt != NULL && opt->filename != NULL; opt++)
+		if (opt->desktop != -1)
+			return 1;
+	return 0;
+}
 
 int
 main(int argc, char *argv[])
@@ -803,7 +821,8 @@ main(int argc, char *argv[])
 
 #ifdef WITH_RANDR
 	if (config->daemon) {
-		if (config->daemon && has_randr == 0)
+		if (config->daemon && has_randr == 0 &&
+		    !has_desktop_option(config))
 			warnx("--daemon requires RandR");
 		else
 			process_events(c, config);

--- a/main.c
+++ b/main.c
@@ -20,6 +20,7 @@
   #include <xcb/randr.h>
 #endif /* WITH_RANDR */
 #include <xcb/xcb.h>
+#include <xcb/xcb_ewmh.h>
 #include <xcb/xcb_image.h>
 
 #include <err.h>
@@ -569,9 +570,20 @@ process_atoms(xcb_connection_t *c, xcb_screen_t *screen, xcb_pixmap_t *pixmap,
 }
 
 static int
-get_current_desktop()
+get_current_desktop(xcb_connection_t *c, int snum)
 {
-	return -1;
+	xcb_ewmh_connection_t ewmh;
+	uint32_t dnum;
+
+	if (!xcb_ewmh_init_atoms_replies(&ewmh,
+	    xcb_ewmh_init_atoms(c, &ewmh), NULL))
+		return -1;
+
+	if (!xcb_ewmh_get_current_desktop_reply(&ewmh,
+	    xcb_ewmh_get_current_desktop(&ewmh, snum), &dnum, NULL))
+		return -1;
+
+	return dnum;
 }
 
 static void
@@ -588,7 +600,7 @@ process_screen(xcb_connection_t *c, xcb_screen_t *screen, int snum,
 	xcb_rectangle_t rectangle;
 	int created, dnum;
 
-	dnum = get_current_desktop();
+	dnum = get_current_desktop(c, snum);
 	options = config->options;
 
 	/* let X perform non-randr tiling if requested */
@@ -709,9 +721,30 @@ usage(void)
 	exit(1);
 }
 
+static void
+process_desktop_event(wp_config_t *config, xcb_connection_t *c,
+    xcb_property_notify_event_t *event, xcb_atom_t cdesk)
+{
+	xcb_screen_iterator_t it;
+	int snum;
+
+	if (event->atom != cdesk)
+		return;
+
+	it = xcb_setup_roots_iterator(xcb_get_setup(c));
+	for (snum = 0; it.rem; snum++, xcb_screen_next(&it))
+		if (it.data->root == event->window) {
+			process_screen(c, it.data, snum, config);
+			break;
+		}
+
+	if (xcb_connection_has_error(c))
+		warnx("error encountered while setting wallpaper");
+}
+
 #ifdef WITH_RANDR
 static void
-process_event(wp_config_t *config, xcb_connection_t *c,
+process_randr_event(wp_config_t *config, xcb_connection_t *c,
     xcb_generic_event_t *event) {
 	xcb_randr_screen_change_notify_event_t *randr_event;
 	xcb_screen_iterator_t it;
@@ -731,22 +764,6 @@ process_event(wp_config_t *config, xcb_connection_t *c,
 	if (xcb_connection_has_error(c))
 		warnx("error encountered while setting wallpaper");
 }
-
-static void
-process_events(xcb_connection_t *c, wp_config_t *config)
-{
-	xcb_screen_iterator_t it = xcb_setup_roots_iterator(xcb_get_setup(c));
-	xcb_generic_event_t *event;
-	int snum;
-
-	for (snum = 0; it.rem; snum++, xcb_screen_next(&it))
-		xcb_request_check(c, xcb_randr_select_input(c,
-		    it.data->root,
-		    XCB_RANDR_NOTIFY_MASK_SCREEN_CHANGE));
-
-	while ((event = xcb_wait_for_event(c)) != NULL)
-		process_event(config, c, event);
-}
 #endif /* WITH_RANDR */
 
 int
@@ -758,6 +775,61 @@ has_desktop_option(wp_config_t *config)
 		if (opt->desktop != -1)
 			return 1;
 	return 0;
+}
+
+static void
+process_events(xcb_connection_t *c, wp_config_t *config)
+{
+	xcb_screen_iterator_t it = xcb_setup_roots_iterator(xcb_get_setup(c));
+	xcb_generic_event_t *event;
+	xcb_atom_t cdesk;
+	int snum;
+
+	for (snum = 0; it.rem; snum++, xcb_screen_next(&it)) {
+#ifdef WITH_RANDR
+		if (has_randr == 1)
+			xcb_request_check(c, xcb_randr_select_input(c,
+			    it.data->root,
+			    XCB_RANDR_NOTIFY_MASK_SCREEN_CHANGE));
+#endif /* WITH_RANDR */
+		if (has_desktop_option(config)) {
+			const char *name = "_NET_CURRENT_DESKTOP";
+			xcb_intern_atom_cookie_t cookie;
+			xcb_intern_atom_reply_t *reply;
+
+			cookie = xcb_intern_atom(c, 0, strlen(name), name);
+			reply = xcb_intern_atom_reply(c, cookie, NULL);
+
+			if (reply != NULL) {
+				uint32_t pchange[] = {
+				    XCB_EVENT_MASK_PROPERTY_CHANGE
+				};
+
+				cdesk = reply->atom;
+				free(reply);
+
+				xcb_request_check(c,
+				    xcb_change_window_attributes_checked(c,
+				    it.data->root, XCB_CW_EVENT_MASK, pchange));
+			}
+		}
+	}
+
+	while ((event = xcb_wait_for_event(c)) != NULL) {
+		switch (event->response_type) {
+		case XCB_PROPERTY_NOTIFY:
+			process_desktop_event(config, c,
+			    (xcb_property_notify_event_t *) event, cdesk);
+			break;
+#ifdef WITH_RANDR
+		case XCB_RANDR_SCREEN_CHANGE_NOTIFY:
+			process_randr_event(config, c, event);
+			break;
+#endif /* WITH_RANDR */
+		default:
+			break;
+		}
+	}
 }
 
 int
@@ -819,15 +891,13 @@ main(int argc, char *argv[])
 	if (xcb_connection_has_error(c))
 		warnx("error encountered while setting wallpaper");
 
-#ifdef WITH_RANDR
 	if (config->daemon) {
 		if (config->daemon && has_randr == 0 &&
 		    !has_desktop_option(config))
-			warnx("--daemon requires RandR");
+			warnx("--daemon requires --desktop or RandR");
 		else
 			process_events(c, config);
 	}
-#endif /* WITH_RANDR */
 
 	xcb_disconnect(c);
 

--- a/main.c
+++ b/main.c
@@ -576,7 +576,7 @@ process_screen(xcb_connection_t *c, xcb_screen_t *screen, int snum,
 	xcb_gcontext_t gc;
 	xcb_get_geometry_cookie_t geom_cookie;
 	xcb_get_geometry_reply_t *geom_reply;
-	wp_output_t *outputs, tile_output;
+	wp_output_t *outputs, tile_output[2];
 	wp_option_t *opt, *options;
 	uint16_t width, height;
 	xcb_rectangle_t rectangle;
@@ -585,21 +585,25 @@ process_screen(xcb_connection_t *c, xcb_screen_t *screen, int snum,
 	options = config->options;
 
 	/* let X perform non-randr tiling if requested */
-	if (options != NULL && options[0].mode == MODE_TILE &&
-	    options[0].output == NULL && options[1].filename == NULL) {
+	if (has_randr == 0 && options != NULL && options[0].mode == MODE_TILE &&
+	    strcmp(options[0].output, "all") == 0 &&
+	    options[1].filename == NULL) {
 		pixman_image_t *pixman_image = options->buffer->pixman_image;
 
 		/* fake an output that fits the picture */
 		width = pixman_image_get_width(pixman_image);
 		height = pixman_image_get_height(pixman_image);
-		tile_output = (wp_output_t){
+		tile_output[0] = (wp_output_t){
 			.x = 0,
 			.y = 0,
 			.width = width,
 			.height = height,
+			.name = "all"
+		};
+		tile_output[1] = (wp_output_t){
 			.name = NULL
 		};
-		outputs = &tile_output;
+		outputs = tile_output;
 	} else {
 		width = screen->width_in_pixels;
 		height = screen->height_in_pixels;
@@ -654,8 +658,7 @@ process_screen(xcb_connection_t *c, xcb_screen_t *screen, int snum,
 		if (opt->screen != -1 && opt->screen != snum)
 			continue;
 
-		if (opt->output != NULL &&
-		    strcmp(opt->output, "all") == 0)
+		if (strcmp(opt->output, "all") == 0)
 			for (output = outputs; output->name != NULL; output++)
 				process_output(c, screen, output, opt,
 				    pixmap, gc);
@@ -692,7 +695,7 @@ process_screen(xcb_connection_t *c, xcb_screen_t *screen, int snum,
 		xcb_free_pixmap(c, pixmap);
 	xcb_request_check(c, xcb_clear_area(c, 0, screen->root, 0, 0, 0, 0));
 
-	if (outputs != &tile_output)
+	if (outputs != tile_output)
 		free_outputs(outputs);
 }
 

--- a/main.c
+++ b/main.c
@@ -576,7 +576,7 @@ process_screen(xcb_connection_t *c, xcb_screen_t *screen, int snum,
 	xcb_gcontext_t gc;
 	xcb_get_geometry_cookie_t geom_cookie;
 	xcb_get_geometry_reply_t *geom_reply;
-	wp_output_t *outputs, tile_output[2];
+	wp_output_t *output, *outputs, tile_output[2];
 	wp_option_t *opt, *options;
 	uint16_t width, height;
 	xcb_rectangle_t rectangle;
@@ -651,23 +651,14 @@ process_screen(xcb_connection_t *c, xcb_screen_t *screen, int snum,
 		created = 0;
 	}
 
-	for (opt = options; opt != NULL && opt->filename != NULL; opt++) {
-		wp_output_t *output;
+	for (output = outputs; output->name != NULL; output++) {
+		wp_option_t *opt;
 
-		/* ignore options which are not relevant for this screen */
-		if (opt->screen != -1 && opt->screen != snum)
+		opt = get_option(options, snum, output->name);
+		if (opt == NULL)
 			continue;
 
-		if (strcmp(opt->output, "all") == 0)
-			for (output = outputs; output->name != NULL; output++)
-				process_output(c, screen, output, opt,
-				    pixmap, gc);
-		else {
-			output = get_output(outputs, opt->output);
-			if (output != NULL)
-				process_output(c, screen, output, opt,
-				    pixmap, gc);
-		}
+		process_output(c, screen, output, opt, pixmap, gc);
 	}
 
 	if (options == NULL)

--- a/options.c
+++ b/options.c
@@ -64,9 +64,11 @@ add_option(wp_config_t *config, wp_option_t option)
 		    config->options[i].screen == option.screen)
 			break;
 
-	if (i != config->count)
-		o = config->options + i;
-	else {
+	if (i != config->count) {
+		memmove(config->options + i, config->options + i + 1,
+		    (config->count - i) * sizeof(option));
+		o = config->options + config->count - 1;
+	} else {
 		config->options = realloc(config->options,
 		    (config->count + 2) * sizeof(*config->options));
 		if (config->options == NULL)

--- a/options.c
+++ b/options.c
@@ -79,6 +79,28 @@ add_option(wp_config_t *config, wp_option_t option)
 	*o = option;
 }
 
+static int
+streq_all(const char *s1, const char *s2)
+{
+	if (strcmp(s1, "all") == 0 || strcmp(s2, "all") == 0)
+		return 1;
+	return strcmp(s1, s2) == 0;
+}
+
+wp_option_t *
+get_option(wp_option_t *options, int snum, const char *output)
+{
+	wp_option_t *opt, *result;
+
+	result = NULL;
+	for (opt = options; opt != NULL && opt->filename != NULL; opt++)
+		if ((opt->screen == -1 || opt->screen == snum) &&
+		    streq_all(opt->output, output))
+			result = opt;
+
+	return result;
+}
+
 static void
 init_buffers(wp_config_t *config)
 {

--- a/options.c
+++ b/options.c
@@ -235,7 +235,7 @@ parse_config(char **argv)
 				return NULL;
 			}
 			add_option(config, last);
-			last.desktop = -1; /*parse_int(*argv);*/
+			last.desktop = parse_int(*argv);
 			last.filename = NULL;
 			last.mode = 0;
 			last.output = "all";

--- a/options.c
+++ b/options.c
@@ -61,7 +61,8 @@ add_option(wp_config_t *config, wp_option_t option)
 
 	for (i = 0; i < config->count; i++)
 		if (strcmp(config->options[i].output, option.output) == 0 &&
-		    config->options[i].screen == option.screen)
+		    config->options[i].screen == option.screen &&
+		    config->options[i].desktop == option.desktop)
 			break;
 
 	if (i != config->count) {
@@ -88,13 +89,14 @@ streq_all(const char *s1, const char *s2)
 }
 
 wp_option_t *
-get_option(wp_option_t *options, int snum, const char *output)
+get_option(wp_option_t *options, int snum, int dnum, const char *output)
 {
 	wp_option_t *opt, *result;
 
 	result = NULL;
 	for (opt = options; opt != NULL && opt->filename != NULL; opt++)
 		if ((opt->screen == -1 || opt->screen == snum) &&
+		    (opt->desktop == -1 || opt->desktop == dnum) &&
 		    streq_all(opt->output, output))
 			result = opt;
 
@@ -215,6 +217,7 @@ parse_config(char **argv)
 	};
 
 	last = (wp_option_t){
+		.desktop = -1,
 		.output = "all",
 		.screen = -1
 	};
@@ -226,7 +229,18 @@ parse_config(char **argv)
 			show_debug = 1;
 		else if (strcmp(argv[0], "--clear") == 0)
 			config->source = 0;
-		else if (strcmp(argv[0], "--no-atoms") == 0) {
+		else if (strcmp(argv[0], "--desktop") == 0) {
+			if (*++argv == NULL) {
+				warnx("missing argument for --desktop");
+				return NULL;
+			}
+			add_option(config, last);
+			last.desktop = -1; /*parse_int(*argv);*/
+			last.filename = NULL;
+			last.mode = 0;
+			last.output = "all";
+			last.trim = NULL;
+		} else if (strcmp(argv[0], "--no-atoms") == 0) {
 			config->target &= ~TARGET_ATOMS;
 			if (config->target == 0) {
 				warnx("--no-atoms conflicts with --no-root");
@@ -244,6 +258,7 @@ parse_config(char **argv)
 				return NULL;
 			}
 			add_option(config, last);
+			last.desktop = -1;
 			last.filename = NULL;
 			last.mode = 0;
 			last.output = "all";

--- a/options.c
+++ b/options.c
@@ -60,8 +60,7 @@ add_option(wp_config_t *config, wp_option_t option)
 		return;
 
 	for (i = 0; i < config->count; i++)
-		if (config->options[i].output != NULL &&
-		    strcmp(config->options[i].output, option.output) == 0 &&
+		if (strcmp(config->options[i].output, option.output) == 0 &&
 		    config->options[i].screen == option.screen)
 			break;
 
@@ -138,9 +137,12 @@ parse_int(char *string)
 	char *endptr;
 	long value;
 
+	if (strcmp(string, "all") == 0)
+		return -1;
+
 	value = strtol(string, &endptr, 10);
 	if (endptr == string || *endptr != '\0' || value < 0 || value > INT_MAX)
-		errx(1, "failed to parse screen number: %s", string);
+		errx(1, "failed to parse number: %s", string);
 	return value;
 }
 
@@ -188,7 +190,10 @@ parse_config(char **argv)
 		.target = TARGET_ATOMS | TARGET_ROOT
 	};
 
-	last = (wp_option_t){ .screen = -1 };
+	last = (wp_option_t){
+		.output = "all",
+		.screen = -1
+	};
 
 	while (*argv != NULL) {
 		if (strcmp(argv[0], "--daemon") == 0) {
@@ -217,7 +222,7 @@ parse_config(char **argv)
 			add_option(config, last);
 			last.filename = NULL;
 			last.mode = 0;
-			last.output = NULL;
+			last.output = "all";
 			last.screen = parse_int(*argv);
 			last.trim = NULL;
 		} else if (strcmp(argv[0], "--output") == 0) {
@@ -266,8 +271,6 @@ parse_config(char **argv)
 		}
 		++argv;
 	}
-	if (has_randr == -1 && last.output == NULL)
-		last.output = "all";
 	add_option(config, last);
 
 	if (!(config->target & TARGET_ATOMS))

--- a/xwallpaper.1
+++ b/xwallpaper.1
@@ -118,6 +118,9 @@ Please note that a screen is not a single monitor.
 See
 .Fl Fl output
 for such a use case above.
+The special keyword
+.Cm all
+will repeat subsequent actions on all screens, which is the default.
 .It Fl Fl stretch Ar file
 Stretches input file to fully cover the output.
 If the aspect ratio of the input file does not match the output,

--- a/xwallpaper.1
+++ b/xwallpaper.1
@@ -70,6 +70,23 @@ Displays debug messages on the standard error output while
 is running.  If used in conjunction with
 .Fl Fl daemon
 the process will not modify the standard input and outputs.
+.It Fl Fl desktop Ar desktop
+Specifies a desktop by its _NET_CURRENT_DESKTOP property number,
+retrievable with e.g.
+.Cm xprop -root _NET_CURRENT_DESKTOP .
+The special keyword
+.Cm all
+makes the wallpaper default for all desktops for the given screen.
+If
+.Fl Fl desktop
+is used without
+.Fl Fl daemon ,
+then
+.Nm xwallpaper
+will only adjust the screen if current desktop matches the specified desktop.
+With
+.Fl Fl daemon ,
+it changes the desktop whenever the virtual desktop becomes active.
 .It Fl Fl focus Ar file
 In conjunction with
 .Fl Fl trim
@@ -167,6 +184,9 @@ Centers and recenters a JPEG file after output updates on all outputs:
 .Pp
 Tiles a JPEG file as a wallpaper on VGA-1 and zooms into a PNG file on LVDS-1:
 .Dl $ xwallpaper --output VGA-1 --tile file.jpg --output LVDS-1 --zoom file.png
+.Pp
+Special wallpaper on desktop 3:
+.Dl $ xwallpaper --daemon --zoom file.jpg --desktop 3 --zoom file.png
 .Sh BUGS
 Use the GitHub issue tracker:
 .Lk https://github.com/stoeckmann/xwallpaper/issues


### PR DESCRIPTION
Based on https://github.com/stoeckmann/xwallpaper/pull/55

If only one desktop is specified, e.g. `--desktop 2` and you switch away from it, then wallpapers stay the way they are. If it's `--desktop 2` and `--desktop 4` and you switch from 2 to 4 to 3, 3 will have the desktop 4 wallpaper. If you switch from 2 to 3, it will have the desktop 2 wallpaper. The `--clear` option fixes that. Probably worth a manual page entry.

Otherwise, tested with multi-monitor setup.